### PR TITLE
Fix hardcoded footer Data since year (#4)

### DIFF
--- a/resources/lang/ca-es.json
+++ b/resources/lang/ca-es.json
@@ -549,7 +549,7 @@
     "Data from our weatherstation": "Dades de la nostra estació meteorològica",
     "Data Provided by": "Dades subministrades per ",
     "Data since": "Dades des de",
-    "Data since 2020": "Dades des del 2020",
+    "Data since :year": "Dades des del :year",
     "Data source": "Data source",
     "Database": "Base de dades",
     "Database Size": "Mida de la base de dades",

--- a/resources/lang/da-dk.json
+++ b/resources/lang/da-dk.json
@@ -549,7 +549,7 @@
     "Data from our weatherstation": "Data fra vejrstationen",
     "Data Provided by": "Data leveret af",
     "Data since": "Data siden",
-    "Data since 2020": "Data siden 2020",
+    "Data since :year": "Data siden :year",
     "Data source": "Data source",
     "Database": "Database",
     "Database Size": "Databasestørrelse",

--- a/resources/lang/de-de.json
+++ b/resources/lang/de-de.json
@@ -551,7 +551,7 @@
     "Data from our weatherstation": "Daten von unserer Wetterstation",
     "Data Provided by": "Daten zur Verfügung gestellt von",
     "Data since": "Daten seit",
-    "Data since 2020": "Daten seit 2020",
+    "Data since :year": "Daten seit :year",
     "Data source": "Datenquelle",
     "Database": "Datenbank",
     "Database Size": "Datenbankgröße",

--- a/resources/lang/el-gr.json
+++ b/resources/lang/el-gr.json
@@ -549,7 +549,7 @@
     "Data from our weatherstation": "Δεδομένα από τον καιρό σας",
     "Data Provided by": "Δεδομένα που παρέχονται από το",
     "Data since": "Δεδομένα από",
-    "Data since 2020": "Δεδομένα από το 2020",
+    "Data since :year": "Δεδομένα από το :year",
     "Data source": "Data source",
     "Database": "Βάση δεδομένων",
     "Database Size": "Μέγεθος βάσης δεδομένων",

--- a/resources/lang/en-gb.json
+++ b/resources/lang/en-gb.json
@@ -625,7 +625,7 @@
     "Data Provided by": "Data Provided by",
     "Data Retention Days": "Data Retention Days",
     "Data since": "Data since",
-    "Data since 2020": "Data since 2020",
+    "Data since :year": "Data since :year",
     "Data source": "Data source",
     "Data Sources": "Data Sources",
     "Database": "Database",

--- a/resources/lang/en-us.json
+++ b/resources/lang/en-us.json
@@ -625,7 +625,7 @@
     "Data Provided by": "Data Provided by",
     "Data Retention Days": "Data Retention Days",
     "Data since": "Data since",
-    "Data since 2020": "Data since 2020",
+    "Data since :year": "Data since :year",
     "Data source": "Data source",
     "Data Sources": "Data Sources",
     "Database": "Database",

--- a/resources/lang/es-es.json
+++ b/resources/lang/es-es.json
@@ -551,7 +551,7 @@
     "Data from our weatherstation": "Datos de nuestra estación meteorológican",
     "Data Provided by": "Datos proporcionados por",
     "Data since": "Datos desde",
-    "Data since 2020": "Datos desde 2020",
+    "Data since :year": "Datos desde :year",
     "Data source": "Data source",
     "Database": "Base de datos",
     "Database Size": "Tamaño de la base de datos",

--- a/resources/lang/fi-fi.json
+++ b/resources/lang/fi-fi.json
@@ -549,7 +549,7 @@
     "Data from our weatherstation": "Tiedot sääasemaltamme",
     "Data Provided by": "Tiedot tarjoaa",
     "Data since": "Tietoja alkaen",
-    "Data since 2020": "Tiedot vuodesta 2020 lähtien",
+    "Data since :year": "Tiedot vuodesta :year lähtien",
     "Data source": "Data source",
     "Database": "Tietokanta",
     "Database Size": "Tietokannan koko",

--- a/resources/lang/fr-fr.json
+++ b/resources/lang/fr-fr.json
@@ -551,7 +551,7 @@
     "Data from our weatherstation": "Les données de la station météo",
     "Data Provided by": "Données fournies par",
     "Data since": "Données depuis",
-    "Data since 2020": "Données depuis 2020",
+    "Data since :year": "Données depuis :year",
     "Data source": "Data source",
     "Database": "Base de données",
     "Database Size": "Taille de la base de données",

--- a/resources/lang/hr-hr.json
+++ b/resources/lang/hr-hr.json
@@ -549,7 +549,7 @@
     "Data from our weatherstation": "Podaci s naše meteo postaje",
     "Data Provided by": "Podatke pruža",
     "Data since": "Podaci od",
-    "Data since 2020": "Podaci od 2020.",
+    "Data since :year": "Podaci od :year.",
     "Data source": "Data source",
     "Database": "Baza podataka",
     "Database Size": "Veličina baze podataka",

--- a/resources/lang/it-it.json
+++ b/resources/lang/it-it.json
@@ -551,7 +551,7 @@
     "Data from our weatherstation": "Dati dal nostro weatherstation",
     "Data Provided by": "Dati forniti da",
     "Data since": "Dati dal",
-    "Data since 2020": "Dati dal 2020",
+    "Data since :year": "Dati dal :year",
     "Data source": "Data source",
     "Database": "Database",
     "Database Size": "Dimensione del database",

--- a/resources/lang/nl-nl.json
+++ b/resources/lang/nl-nl.json
@@ -603,7 +603,7 @@
     "Data Provided by": "Gegevens afkomstig van",
     "Data Retention Days": "Dagen waarop gegevens worden bewaard",
     "Data since": "Data sinds",
-    "Data since 2020": "Data sinds 2020",
+    "Data since :year": "Data sinds :year",
     "Data source": "Databron",
     "Data Sources": "Databronnen",
     "Database": "Database",

--- a/resources/lang/nn-no.json
+++ b/resources/lang/nn-no.json
@@ -549,7 +549,7 @@
     "Data from our weatherstation": "Data fra værstasjonen",
     "Data Provided by": "Data levert av",
     "Data since": "Data sidan",
-    "Data since 2020": "Data siden 2020",
+    "Data since :year": "Data siden :year",
     "Data source": "Data source",
     "Database": "Database",
     "Database Size": "Databasestørrelse",

--- a/resources/lang/pl-pl.json
+++ b/resources/lang/pl-pl.json
@@ -549,7 +549,7 @@
     "Data from our weatherstation": "Dane ze stacji",
     "Data Provided by": "Dane dostarczone przez",
     "Data since": "Dane od",
-    "Data since 2020": "Dane od 2020 r.",
+    "Data since :year": "Dane od :year r.",
     "Data source": "Data source",
     "Database": "Baza danych",
     "Database Size": "Rozmiar bazy danych",

--- a/resources/lang/pt-br.json
+++ b/resources/lang/pt-br.json
@@ -549,7 +549,7 @@
     "Data from our weatherstation": "Dados da nossa estação meteorológica",
     "Data Provided by": "Dados fornecidos por",
     "Data since": "Dados desde",
-    "Data since 2020": "Dados desde 2020",
+    "Data since :year": "Dados desde :year",
     "Data source": "Data source",
     "Database": "Banco de dados",
     "Database Size": "Tamanho do banco de dados",

--- a/resources/lang/pt-pt.json
+++ b/resources/lang/pt-pt.json
@@ -549,7 +549,7 @@
     "Data from our weatherstation": "Dados da nossa estação",
     "Data Provided by": "Dados Fornecidos por",
     "Data since": "Dados desde",
-    "Data since 2020": "Dados desde 2020",
+    "Data since :year": "Dados desde :year",
     "Data source": "Data source",
     "Database": "Base de dados",
     "Database Size": "Tamanho da base de dados",

--- a/resources/lang/sr-rs.json
+++ b/resources/lang/sr-rs.json
@@ -549,7 +549,7 @@
     "Data from our weatherstation": "Podaci sa vaše meteorološke stanice",
     "Data Provided by": "Podaci koje pruža",
     "Data since": "Подаци од",
-    "Data since 2020": "Подаци од 2020. године",
+    "Data since :year": "Подаци од :year. године",
     "Data source": "Data source",
     "Database": "База података",
     "Database Size": "Величина базе података",

--- a/resources/lang/sv-se.json
+++ b/resources/lang/sv-se.json
@@ -549,7 +549,7 @@
     "Data from our weatherstation": "Data från vår väderstation",
     "Data Provided by": "Data tillhandahållna av",
     "Data since": "Data sedan",
-    "Data since 2020": "Data sedan 2020",
+    "Data since :year": "Data sedan :year",
     "Data source": "Data source",
     "Database": "Databas",
     "Database Size": "Databasens storlek",

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -260,9 +260,27 @@
         <div class="max-w-7xl mx-auto px-4">
             <div class="flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-gray-400">
                 <div class="flex items-center gap-4">
-                    <span>Ecowitt WH4000SE</span>
+                    @php
+                        $stationHardware = \App\Models\Setting::getValue('station.hardware', '');
+                        $stationStartDate = \App\Models\Setting::getValue('station.start_date', '');
+                        $stationStartYear = null;
+                        if (is_string($stationStartDate) && $stationStartDate !== '') {
+                            try {
+                                $stationStartYear = \Carbon\Carbon::parse($stationStartDate)->year;
+                            } catch (\Throwable) {
+                                $stationStartYear = null;
+                            }
+                        }
+                    @endphp
+                    @if($stationHardware)
+                    <span>{{ $stationHardware }}</span>
+                    @endif
+                    @if($stationHardware && $stationStartYear)
                     <span>•</span>
-                    <span>{{ __('Data since 2020') }}</span>
+                    @endif
+                    @if($stationStartYear)
+                    <span>{{ __('Data since :year', ['year' => $stationStartYear]) }}</span>
+                    @endif
                 </div>
                 <div class="flex items-center gap-4">
                     <a href="https://yr.no" class="hover:text-white transition-colors">Yr.no</a>

--- a/resources/views/weather/partials/footer.blade.php
+++ b/resources/views/weather/partials/footer.blade.php
@@ -44,6 +44,15 @@
     $stationLocation = \App\Models\Setting::stationLocation();
     $stationLat = \App\Models\Setting::latitude();
     $stationLon = \App\Models\Setting::longitude();
+    $stationStartDate = \App\Models\Setting::getValue('station.start_date', '');
+    $stationStartYear = null;
+    if (is_string($stationStartDate) && $stationStartDate !== '') {
+        try {
+            $stationStartYear = \Carbon\Carbon::parse($stationStartDate)->year;
+        } catch (\Throwable) {
+            $stationStartYear = null;
+        }
+    }
     
     // Social media links
     $socialLinks = [];
@@ -139,10 +148,12 @@
                         <span class="ml-2 font-mono text-xs">{{ number_format($stationLat, 6) }}, {{ number_format($stationLon, 6) }}</span>
                     </li>
                     @endif
+                    @if($stationStartYear)
                     <li>
                         <span class="text-gray-500">{{ __('Data since') }}:</span>
-                        <span class="ml-2">2020</span>
+                        <span class="ml-2">{{ $stationStartYear }}</span>
                     </li>
+                    @endif
                 </ul>
             </div>
             @endif


### PR DESCRIPTION
## Summary
- Read `station.start_date` and show its year in the public footer Station Information block instead of the hardcoded `2020`.
- Update the login footer to use the same setting (and `station.hardware`), with a parameterized `Data since :year` translation across all locales.
- Closes #4