### PR TITLE
Map realtime.txt avg wind direction and daily max gust (#6)

### DIFF
--- a/app/Services/Weather/LocalFiles/RealtimeTxtParser.php
+++ b/app/Services/Weather/LocalFiles/RealtimeTxtParser.php
@@ -46,6 +46,8 @@ class RealtimeTxtParser
         $windSpeed = $this->convertWind($this->getFloat($parts, 6), $windUnits);
         $windAvg = $this->convertWind($this->getFloat($parts, 5), $windUnits);
         $windGust = $this->convertWind($this->getFloat($parts, 40), $windUnits);
+        $windGustMaxDaily = $this->convertWind($this->getFloat($parts, 32), $windUnits);
+        $windDirectionAvg10m = $this->getInt($parts, 46);
 
         $rainRate = $this->convertRain($this->getFloat($parts, 8), $rainUnits);
         $rainToday = $this->convertRain($this->getFloat($parts, 9), $rainUnits);
@@ -69,7 +71,9 @@ class RealtimeTxtParser
             'wind_speed' => $windSpeed,
             'wind_speed_avg_10m' => $windAvg,
             'wind_gust' => $windGust,
+            'wind_gust_max_daily' => $windGustMaxDaily,
             'wind_direction' => $this->getInt($parts, 7),
+            'wind_direction_avg_10m' => $windDirectionAvg10m,
             'rain_rate' => $rainRate,
             'rain_daily' => $rainToday,
             'rain_monthly' => $rainMonth,

--- a/tests/Unit/Services/Weather/RealtimeTxtParserTest.php
+++ b/tests/Unit/Services/Weather/RealtimeTxtParserTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Weather;
+
+use App\Services\Weather\LocalFiles\RealtimeTxtParser;
+use Tests\TestCase;
+
+class RealtimeTxtParserTest extends TestCase
+{
+    public function test_maps_avg_wind_direction_and_daily_max_gust(): void
+    {
+        $parts = array_fill(0, 58, '0');
+        $parts[0] = '30/07/26';
+        $parts[1] = '12:00:00';
+        $parts[2] = '20.0';
+        $parts[3] = '50';
+        $parts[4] = '10.0';
+        $parts[5] = '5.0';
+        $parts[6] = '6.0';
+        $parts[7] = '180';
+        $parts[8] = '0.0';
+        $parts[9] = '1.2';
+        $parts[10] = '1013.0';
+        $parts[13] = 'km/h';
+        $parts[14] = 'C';
+        $parts[15] = 'hPa';
+        $parts[16] = 'mm';
+        $parts[32] = '44.0';
+        $parts[40] = '12.5';
+        $parts[46] = '260';
+        $parts[47] = '0.3';
+
+        $data = (new RealtimeTxtParser())->parseContent(implode(' ', $parts), 'cumulus');
+
+        $this->assertNotNull($data);
+        $this->assertSame(5.0, $data['wind_speed_avg_10m']);
+        $this->assertSame(260, $data['wind_direction_avg_10m']);
+        $this->assertSame(12.5, $data['wind_gust']);
+        $this->assertSame(44.0, $data['wind_gust_max_daily']);
+        $this->assertSame(0.3, $data['rain_hourly']);
+    }
+
+    public function test_converts_daily_max_gust_units(): void
+    {
+        $parts = array_fill(0, 58, '0');
+        $parts[0] = '30/07/26';
+        $parts[1] = '12:00:00';
+        $parts[2] = '20.0';
+        $parts[3] = '50';
+        $parts[4] = '10.0';
+        $parts[5] = '5.0';
+        $parts[6] = '6.0';
+        $parts[7] = '180';
+        $parts[8] = '0.0';
+        $parts[9] = '1.2';
+        $parts[10] = '1013.0';
+        $parts[13] = 'mph';
+        $parts[14] = 'C';
+        $parts[15] = 'hPa';
+        $parts[16] = 'mm';
+        $parts[32] = '10.0';
+        $parts[46] = '90';
+
+        $data = (new RealtimeTxtParser())->parseContent(implode(' ', $parts), 'cumulus');
+
+        $this->assertNotNull($data);
+        $this->assertSame(16.1, $data['wind_gust_max_daily']);
+        $this->assertSame(90, $data['wind_direction_avg_10m']);
+    }
+}


### PR DESCRIPTION
## Summary
- Map Cumulus `realtime.txt` field 47 (`avgbearing`) to `wind_direction_avg_10m` and field 33 (`wgustTM`) to `wind_gust_max_daily`.
- Convert daily max gust with the same wind units as other realtime wind fields.
- Closes #6