### PR TITLE
Localize weekly temperature chart day labels (#10)

### DIFF
--- a/resources/js/pages/dashboard.js
+++ b/resources/js/pages/dashboard.js
@@ -2486,9 +2486,8 @@ function weatherDashboard() {
                     const date = new Date(dateStr);
                     const todayStr = new Date().toLocaleDateString('en-CA', { timeZone: tz });
                     const dateStrNorm = date.toLocaleDateString('en-CA', { timeZone: tz });
-                    if (dateStrNorm === todayStr) return 'Vnd';
-                    const days = ['Zo', 'Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za'];
-                    return days[date.getDay()];
+                    if (dateStrNorm === todayStr) return t('Today');
+                    return date.toLocaleDateString(locale, { timeZone: tz, weekday: 'short' });
                 },
                 
                 // Temperature chart helpers


### PR DESCRIPTION
## Summary
- Replace hardcoded Dutch day labels in `formatShortDay()` with localized `Today` / short weekday names.
- Resolve weekdays in the station timezone so labels stay aligned with the today marker for remote visitors.
- Closes #10

Made with [Cursor](https://cursor.com)