### PR TITLE
Unify jsLocale fallback to en-US

### DIFF
--- a/resources/js/pages/dashboard.js
+++ b/resources/js/pages/dashboard.js
@@ -1,6 +1,6 @@
 const cfg = window.__METEO_DASHBOARD_CONFIG__ || {};
 const t = (key) => cfg.i18n?.[key] ?? key;
-const locale = window.Meteo?.jsLocale || 'nl-NL';
+const locale = window.Meteo?.jsLocale || 'en-US';
 const hybridSsrEnabled = window.__METEO_DASHBOARD_HYBRID__ === true;
 const initialPayload = (window.__METEO_DASHBOARD_INITIAL__ && typeof window.__METEO_DASHBOARD_INITIAL__ === 'object')
     ? window.__METEO_DASHBOARD_INITIAL__
@@ -3221,7 +3221,7 @@ function weatherDashboard() {
                         const controller = new AbortController();
                         const timeoutId = setTimeout(() => controller.abort(), 15000); // 15 second timeout
                         
-                        const lang = (window.Meteo?.jsLocale || 'en-GB').replace('_', '-');
+                        const lang = (window.Meteo?.jsLocale || 'en-US').replace('_', '-');
                         const dashboardUrl = '/api/weather/dashboard' + (lang ? '?lang=' + encodeURIComponent(lang) : '');
                         const res = await fetch(dashboardUrl, {
                             headers: this.getApiHeaders(),

--- a/resources/js/pages/tide-charts.js
+++ b/resources/js/pages/tide-charts.js
@@ -79,7 +79,7 @@ const initTideChart = async () => {
         },
     ];
 
-    const locale = window.Meteo?.jsLocale || 'nl-NL';
+    const locale = window.Meteo?.jsLocale || 'en-US';
 
     const chart = new ApexCharts(el, {
         chart: {

--- a/resources/js/pages/wave-charts.js
+++ b/resources/js/pages/wave-charts.js
@@ -43,7 +43,7 @@ const initWaveChart = async () => {
         },
     ];
 
-    const locale = window.Meteo?.jsLocale || 'nl-NL';
+    const locale = window.Meteo?.jsLocale || 'en-US';
 
     const chart = new ApexCharts(el, {
         chart: {
@@ -160,7 +160,7 @@ const initSstChart = async () => {
 
     const chartData = series.map((p) => ({ x: p.timestamp_unix, y: p.value }));
 
-    const locale = window.Meteo?.jsLocale || 'nl-NL';
+    const locale = window.Meteo?.jsLocale || 'en-US';
 
     const chart = new ApexCharts(el, {
         chart: {

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -296,7 +296,7 @@
         // Update clock (station timezone; DST via IANA + Intl)
         function updateClock() {
             const now = new Date();
-            const locale = window.Meteo?.jsLocale || 'nl-NL';
+            const locale = window.Meteo?.jsLocale || 'en-US';
             const tz = stationTimezone || 'UTC';
             const opts = { timeZone: tz };
             const timeStr = now.toLocaleTimeString(locale, { ...opts, hour: '2-digit', minute: '2-digit', second: '2-digit' });

--- a/resources/views/weather/astronomy.blade.php
+++ b/resources/views/weather/astronomy.blade.php
@@ -638,7 +638,7 @@ function astronomyPage() {
         meteors: [],
         loading: true,
         lastUpdated: null,
-        locale: window.Meteo?.jsLocale || 'nl-NL',
+        locale: window.Meteo?.jsLocale || 'en-US',
         units: window.Meteo?.activeUnits || 'metric',
         moonPhaseLabels: {
             'New Moon': @json(__('New Moon')),

--- a/resources/views/weather/community-stations.blade.php
+++ b/resources/views/weather/community-stations.blade.php
@@ -250,7 +250,7 @@ function communityStations() {
         countryName(code) {
             if (!code || code === '_unknown') return communityI18n.unknownCountry;
             try {
-                const locale = window.Meteo?.jsLocale || 'en';
+                const locale = window.Meteo?.jsLocale || 'en-US';
                 return new Intl.DisplayNames([locale], { type: 'region' }).of(code);
             } catch {
                 return code;
@@ -304,7 +304,7 @@ function communityStations() {
                                 ${station.hardware ? `<p><strong>${communityI18n.hardware}:</strong> ${self.escapeHtml(station.hardware)}</p>` : ''}
                                 ${station.manufacturer ? `<p><strong>${communityI18n.manufacturer}:</strong> ${self.escapeHtml(station.manufacturer)}</p>` : ''}
                                 ${station.url ? `<p><a href="${self.escapeHtml(station.url)}" target="_blank">${communityI18n.visitStation} &rarr;</a></p>` : ''}
-                                ${station.updated_at ? `<p class="text-xs text-gray-500">${communityI18n.updated}: ${new Date(station.updated_at).toLocaleDateString(window.Meteo?.jsLocale || 'nl-NL')}</p>` : ''}
+                                ${station.updated_at ? `<p class="text-xs text-gray-500">${communityI18n.updated}: ${new Date(station.updated_at).toLocaleDateString(window.Meteo?.jsLocale || 'en-US')}</p>` : ''}
                             </div>
                         `;
 

--- a/resources/views/weather/forecast.blade.php
+++ b/resources/views/weather/forecast.blade.php
@@ -218,7 +218,7 @@ function forecastPage() {
         view: 'daily',
         selectedDate: null,
         loading: true,
-        locale: window.Meteo?.jsLocale || 'nl-NL',
+        locale: window.Meteo?.jsLocale || 'en-US',
         units: window.Meteo?.activeUnits || 'metric',
 
         tempUnit() {

--- a/resources/views/weather/layout.blade.php
+++ b/resources/views/weather/layout.blade.php
@@ -347,7 +347,7 @@
         // Update clock (station timezone; DST via IANA + Intl)
         function updateClock() {
             const now = new Date();
-            const locale = window.Meteo?.jsLocale || 'nl-NL';
+            const locale = window.Meteo?.jsLocale || 'en-US';
             const tz = window.Meteo?.stationTimezone || 'UTC';
             const opts = { timeZone: tz };
             const time = now.toLocaleTimeString(locale, { ...opts, hour: '2-digit', minute: '2-digit', second: '2-digit' });

--- a/resources/views/weather/radar.blade.php
+++ b/resources/views/weather/radar.blade.php
@@ -728,7 +728,7 @@ function radarDisplay() {
                 return '';
             }
 
-            const locale = window.Meteo?.jsLocale || 'nl-NL';
+            const locale = window.Meteo?.jsLocale || 'en-US';
             const tz = window.Meteo?.stationTimezone || 'UTC';
             const date = new Date(unixTs * 1000);
             const timeLabel = date.toLocaleTimeString(locale, {
@@ -981,7 +981,7 @@ function precipForecast() {
                 if (updatedAt) {
                     try {
                         const dt = new Date(updatedAt);
-                        const locale = window.Meteo?.jsLocale || 'nl-NL';
+                        const locale = window.Meteo?.jsLocale || 'en-US';
                         this.sourceUpdatedLabel = `${@json(__('Updated'))}: ${dt.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' })}`;
                     } catch (e) {
                         this.sourceUpdatedLabel = '';
@@ -1008,7 +1008,7 @@ function precipForecast() {
                 const unitLabel = useImperial ? 'in' : 'mm';
                 const convert = useImperial ? 0.0393700787 : 1;
 
-                const locale = window.Meteo?.jsLocale || 'nl-NL';
+                const locale = window.Meteo?.jsLocale || 'en-US';
                 this.slots = upcoming.map((h, idx) => {
                     const timeStr = h.time || h.datetime || h.date || '';
                     const dt = new Date(timeStr);


### PR DESCRIPTION
## Summary
- Standardize all `window.Meteo?.jsLocale` fallbacks to `en-US` (replacing mixed `nl-NL` / `en-GB` / `en` defaults).
- Prevents silent Dutch date formatting on pages that load without `jsLocale`.