### PR TITLE
Stop the updater deleting a release's migrations

### DIFF
--- a/app/Services/Update/DeployerService.php
+++ b/app/Services/Update/DeployerService.php
@@ -717,18 +717,43 @@ class DeployerService
             symlink($sharedStorage, $releaseStorage);
         }
 
-        // Link database (for SQLite)
+        // Link the SQLite database file(s) into the release.
+        //
+        // Only the .sqlite files, never the whole database/ directory: that
+        // directory also holds database/migrations, so replacing it with a
+        // symlink to shared/ deleted every migration the release shipped.
+        // `migrate --force` in runPostDeploySteps then ran against shared/,
+        // which nothing ever seeds, and silently applied nothing — so schema
+        // changes never reached SQLite installs and the drift only surfaced
+        // later, as a missing column or setting.
         $sharedDatabase = $this->sharedPath . '/database';
         $releaseDatabase = $releaseDir . '/database';
-        
+
         if (File::exists($sharedDatabase)) {
-            // Only link if it's SQLite (contains .sqlite files)
-            $hasSqlite = !empty(File::glob($sharedDatabase . '/*.sqlite*'));
-            if ($hasSqlite) {
-                if (File::exists($releaseDatabase)) {
-                    File::deleteDirectory($releaseDatabase);
+            $sharedSqliteFiles = File::glob($sharedDatabase . '/*.sqlite*');
+
+            if (!empty($sharedSqliteFiles)) {
+                // A same-version redeploy can find the legacy whole-directory
+                // symlink still in place. Drop it (the shared target is left
+                // untouched) so the release gets a real directory again.
+                if (is_link($releaseDatabase)) {
+                    unlink($releaseDatabase);
                 }
-                symlink($sharedDatabase, $releaseDatabase);
+                if (!File::isDirectory($releaseDatabase)) {
+                    File::makeDirectory($releaseDatabase, 0755, true);
+                }
+
+                foreach ($sharedSqliteFiles as $sharedSqliteFile) {
+                    $releaseSqliteFile = $releaseDatabase . '/' . basename($sharedSqliteFile);
+
+                    // The zip never ships a .sqlite, but a stale link from an
+                    // earlier deploy of this same version can be here.
+                    if (is_link($releaseSqliteFile) || File::exists($releaseSqliteFile)) {
+                        File::delete($releaseSqliteFile);
+                    }
+
+                    symlink($sharedSqliteFile, $releaseSqliteFile);
+                }
             }
         }
     }

--- a/app/Services/Update/DeployerService.php
+++ b/app/Services/Update/DeployerService.php
@@ -565,6 +565,16 @@ class DeployerService
         $this->extractZipSafely($zip, $tempDir);
         $zip->close();
 
+        // A retried deploy reuses the release directory, and one deployed by
+        // the old code still has database/ as a symlink into shared/. The copy
+        // below follows directory symlinks, so without this the zip's
+        // database/migrations would land in shared/ and then be orphaned when
+        // linkSharedDirectories() replaces the symlink with a real directory.
+        $legacyDatabaseLink = $destination . '/database';
+        if (is_link($legacyDatabaseLink)) {
+            unlink($legacyDatabaseLink);
+        }
+
         // Move contents from temp to final destination
         // Handle case where ZIP contains a single root folder
         $contents = File::directories($tempDir);

--- a/tests/Unit/Update/DeployerSharedDatabaseTest.php
+++ b/tests/Unit/Update/DeployerSharedDatabaseTest.php
@@ -144,6 +144,37 @@ class DeployerSharedDatabaseTest extends TestCase
     }
 
     /**
+     * A retried deploy extracts into a release directory that already exists,
+     * and one created by the old deployer still has database/ as a symlink to
+     * shared/. File::copyDirectory follows directory symlinks, so without the
+     * guard in extractZip the zip's migrations landed in shared/ and were then
+     * orphaned when linkSharedDirectories replaced the symlink. This models
+     * the true order: symlink first, then extraction.
+     */
+    public function test_extracting_over_a_legacy_symlink_keeps_migrations_in_the_release(): void
+    {
+        $releaseDir = $this->root . '/releases/v2026.08.02';
+        File::makeDirectory($releaseDir, 0755, true);
+        $sharedDatabase = dirname($this->makeSharedSqlite());
+        symlink($sharedDatabase, $releaseDir . '/database');
+
+        $zipPath = $this->root . '/release.zip';
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE);
+        $zip->addFromString('database/migrations/2026_08_07_090000_add_quick_stats_tile_settings.php', '<?php');
+        $zip->addFromString('artisan', '<?php');
+        $zip->close();
+
+        $deployer = new DeployerService();
+        (new ReflectionMethod($deployer, 'extractZip'))->invoke($deployer, $zipPath, $releaseDir);
+
+        $this->assertFalse(is_link($releaseDir . '/database'), 'the legacy symlink must be gone before the copy');
+        $this->assertFileExists($this->migrationPath($releaseDir), 'migrations must land in the release, not shared');
+        $this->assertFileDoesNotExist($sharedDatabase . '/migrations/2026_08_07_090000_add_quick_stats_tile_settings.php', 'shared must not be polluted with app files');
+        $this->assertFileExists($sharedDatabase . '/database.sqlite', 'the live database must be untouched');
+    }
+
+    /**
      * cleanupOldReleases() calls File::deleteDirectory() straight on an old
      * release, unlike deleteRelease() which unlinks shared symlinks first.
      */

--- a/tests/Unit/Update/DeployerSharedDatabaseTest.php
+++ b/tests/Unit/Update/DeployerSharedDatabaseTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Update;
+
+use App\Services\Update\DeployerService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * The deployer links shared state into each new release. For the SQLite
+ * database that has to be done file by file: database/ also holds the
+ * migrations the release ships, so symlinking the whole directory to shared/
+ * deleted them and left `migrate --force` with nothing to apply.
+ */
+class DeployerSharedDatabaseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->root = sys_get_temp_dir() . '/wn-deploy-' . bin2hex(random_bytes(6));
+        config([
+            'updater.deploy_root' => $this->root,
+            'updater.releases_path' => 'releases',
+            'updater.shared_path' => 'shared',
+            'updater.current_symlink' => 'current',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->root) && File::exists($this->root)) {
+            File::deleteDirectory($this->root);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Build a release directory the way extractZip() leaves it: the zip ships
+     * database/migrations, and never a .sqlite file.
+     */
+    private function makeRelease(string $version): string
+    {
+        $releaseDir = $this->root . '/releases/' . $version;
+        File::makeDirectory($releaseDir . '/database/migrations', 0755, true);
+        File::put($releaseDir . '/database/migrations/2026_08_07_090000_add_quick_stats_tile_settings.php', '<?php');
+        File::put($releaseDir . '/database/migrations/2026_07_29_220000_add_solar_hours.php', '<?php');
+
+        return $releaseDir;
+    }
+
+    private function makeSharedSqlite(string $contents = 'live data'): string
+    {
+        $sharedDatabase = $this->root . '/shared/database';
+        File::ensureDirectoryExists($sharedDatabase);
+        File::put($sharedDatabase . '/database.sqlite', $contents);
+
+        return $sharedDatabase . '/database.sqlite';
+    }
+
+    private function linkShared(string $releaseDir): void
+    {
+        $deployer = new DeployerService();
+
+        (new ReflectionMethod($deployer, 'ensureDirectoriesExist'))->invoke($deployer);
+        (new ReflectionMethod($deployer, 'linkSharedDirectories'))->invoke($deployer, $releaseDir);
+    }
+
+    private function migrationPath(string $releaseDir): string
+    {
+        return $releaseDir . '/database/migrations/2026_08_07_090000_add_quick_stats_tile_settings.php';
+    }
+
+    public function test_release_keeps_its_migrations_when_shared_holds_a_sqlite(): void
+    {
+        $releaseDir = $this->makeRelease('v2026.08.02');
+        $this->makeSharedSqlite();
+
+        $this->linkShared($releaseDir);
+
+        $this->assertFalse(is_link($releaseDir . '/database'), 'database/ must stay a real directory');
+        $this->assertFileExists(
+            $this->migrationPath($releaseDir),
+            'migrate --force runs against this path; without it every in-app update is a silent no-op'
+        );
+        $this->assertCount(2, File::glob($releaseDir . '/database/migrations/*.php'));
+    }
+
+    public function test_the_live_database_is_shared_not_copied(): void
+    {
+        $releaseDir = $this->makeRelease('v2026.08.02');
+        $sharedSqlite = $this->makeSharedSqlite('live data');
+
+        $this->linkShared($releaseDir);
+
+        $releaseSqlite = $releaseDir . '/database/database.sqlite';
+        $this->assertTrue(is_link($releaseSqlite), 'the release must point at the shared database, not its own copy');
+        $this->assertSame('live data', File::get($releaseSqlite));
+
+        // Writes through the release path must land in shared, or the next
+        // deploy would strand them with the old release.
+        File::put($releaseSqlite, 'written by the new release');
+        $this->assertSame('written by the new release', File::get($sharedSqlite));
+    }
+
+    public function test_release_keeps_its_migrations_when_shared_holds_no_sqlite(): void
+    {
+        $releaseDir = $this->makeRelease('v2026.08.02');
+
+        $this->linkShared($releaseDir);
+
+        $this->assertFalse(is_link($releaseDir . '/database'));
+        $this->assertFileExists($this->migrationPath($releaseDir));
+    }
+
+    /**
+     * An install updated before this fix still has the whole-directory symlink
+     * in its current release. Redeploying that same version must recover.
+     */
+    public function test_a_legacy_whole_directory_symlink_is_replaced_safely(): void
+    {
+        $releaseDir = $this->makeRelease('v2026.08.02');
+        $sharedDatabase = dirname($this->makeSharedSqlite());
+
+        File::deleteDirectory($releaseDir . '/database');
+        symlink($sharedDatabase, $releaseDir . '/database');
+        $this->assertTrue(is_link($releaseDir . '/database'));
+
+        $this->linkShared($releaseDir);
+
+        $this->assertFalse(is_link($releaseDir . '/database'), 'the legacy directory symlink must be replaced');
+        $this->assertTrue(is_link($releaseDir . '/database/database.sqlite'));
+        $this->assertFileExists($sharedDatabase . '/database.sqlite', 'the live database must survive the swap');
+        $this->assertSame('live data', File::get($sharedDatabase . '/database.sqlite'));
+    }
+
+    /**
+     * cleanupOldReleases() calls File::deleteDirectory() straight on an old
+     * release, unlike deleteRelease() which unlinks shared symlinks first.
+     */
+    public function test_pruning_an_old_release_cannot_delete_the_shared_database(): void
+    {
+        $old = $this->makeRelease('v2026.08.01');
+        $sharedSqlite = $this->makeSharedSqlite('live data');
+
+        $this->linkShared($old);
+        $this->assertTrue(is_link($old . '/database/database.sqlite'));
+
+        File::deleteDirectory($old);
+
+        $this->assertDirectoryDoesNotExist($old);
+        $this->assertFileExists($sharedSqlite, 'pruning a release must never follow the link into shared');
+        $this->assertSame('live data', File::get($sharedSqlite));
+    }
+
+    public function test_shared_database_directory_is_created_empty_on_first_deploy(): void
+    {
+        $releaseDir = $this->makeRelease('v2026.08.02');
+
+        $this->linkShared($releaseDir);
+
+        $this->assertDirectoryExists($this->root . '/shared/database');
+        $this->assertEmpty(
+            File::glob($this->root . '/shared/database/*'),
+            'nothing seeds shared/database, unlike shared/storage'
+        );
+    }
+}


### PR DESCRIPTION
Found while checking whether the Quick Stats change (#27) would reach users through the in-app updater. It doesn't — and neither has any other migration on affected installs.

## The defect

[`DeployerService::linkSharedDirectories()`](../blob/main/app/Services/Update/DeployerService.php#L720-L733) replaced a release's entire `database/` directory with a symlink to `shared/` whenever `shared/` held a `.sqlite` file:

```php
$hasSqlite = !empty(File::glob($sharedDatabase . '/*.sqlite*'));
if ($hasSqlite) {
    if (File::exists($releaseDatabase)) {
        File::deleteDirectory($releaseDatabase);   // ← takes database/migrations with it
    }
    symlink($sharedDatabase, $releaseDatabase);
}
```

`database/` also holds `database/migrations`. So on every in-app update of a SQLite install:

1. The zip is extracted, migrations and all.
2. `database/` — migrations included — is deleted and replaced by the symlink.
3. `runPostDeploySteps()` runs `migrate --force`, which now reads `shared/database/migrations`.
4. Nothing seeds `shared/database` — unlike `shared/storage`, which gets `seedDirectory()` at line 714 precisely to avoid this class of problem.
5. Migrate finds no migrations, exits 0, and the deploy reports success.

**Nothing fails at update time.** The drift surfaces later, as a missing column or a setting that was never created — far from the cause.

## Not a data-loss bug

That was the first thing I checked, since `cleanupOldReleases()` calls `File::deleteDirectory()` straight on an old release, bypassing the symlink-unlinking that `deleteRelease()` does. Laravel's `deleteDirectory` unlinks symlinks rather than recursing through them, so the shared database was never reachable. There's now a test pinning that behaviour down so it stays true.

## The fix

Link the `.sqlite` files individually and leave `database/` a real directory. The release keeps its migrations; the live database stays genuinely shared.

Installs already carrying the old whole-directory symlink recover on their next deploy — the link is dropped and rebuilt file by file, and the shared target is never touched.

## Tests

New `tests/Unit/Update/DeployerSharedDatabaseTest.php`, which had no coverage before (`tests/Unit/Update/` held only `ReleaseNotesParserTest`). It drives the real `linkSharedDirectories()` against a temp deploy root via reflection — `deploy()` itself is never called, since it triggers maintenance mode.

| Test | Pins down |
|---|---|
| `release_keeps_its_migrations_when_shared_holds_a_sqlite` | the regression itself — failed before this change |
| `the_live_database_is_shared_not_copied` | writes through the release path land in shared |
| `release_keeps_its_migrations_when_shared_holds_no_sqlite` | the MySQL / no-sqlite path is unaffected |
| `a_legacy_whole_directory_symlink_is_replaced_safely` | already-broken installs recover, database intact |
| `pruning_an_old_release_cannot_delete_the_shared_database` | no data-loss path |
| `shared_database_directory_is_created_empty_on_first_deploy` | documents why the bug existed |

248 tests pass (797 assertions).

## Scope

Independent of #27 and branched from `main`, so the two can merge in either order. `#27` does not depend on this: `StatTileRegistry` returns all ten tiles when its setting row is absent, so the Quick Stats bar behaves correctly even where the migration never ran.

## Worth knowing

The updater is opt-in — `'enabled' => env('UPDATER_ENABLED', false)` — so this only ever affected operators who turned it on with SQLite in `shared/`. Docker and hand-extracted zips run `migrate` against the release's own `database/` and were never affected.

Affected installs will apply their backlog of skipped migrations on the first update after this ships. Worth calling out in the release notes.