### PR TITLE
Move the SQLite volume out of the app directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Docker upgrades stopped applying database migrations.** The SQLite volume was mounted at `/var/www/html/database`, which also holds `database/migrations`. Docker only copies a named volume's contents from the image the first time the volume is created, so that directory stayed frozen at whatever shipped the day the install was set up. Every later image pull ran new code against old migrations while `migrate` reported success.
+  - Migrations are now applied from a copy inside the image that no volume can cover, so existing installs are fixed without touching their compose file. Any migrations skipped while the old layout was in place are applied on the first start after upgrading.
+  - The data volume moves to `/var/lib/weathernode`, outside the application directory. This is optional cleanup, not a required step. Nothing is copied or moved: it is the same volume mounted at a different path. See DOCKER.md, "Upgrading from a pre-2026.08 compose file".
+  - Affected installs show a notice in the admin area until the volume is moved.
+
 ### Added
 
 - **In-page weather alert toasts** — non-intrusive slide-down notifications at the top-center of the dashboard for extreme conditions

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -144,8 +144,12 @@ from the image the first time the volume is created, so every later image pull
 ran new code against the migrations the volume was created with. New migrations
 were never applied and `migrate` reported success anyway.
 
-The volume now mounts outside the application directory. Update two things in
-`docker-compose.yml`:
+**Nothing breaks if you do nothing.** The container keeps using the database
+where it already is, and migrations are applied from a copy inside the image
+that no volume can cover, so an old compose file gets its migrations correctly.
+The startup log points out the change each time.
+
+When convenient, move the volume out of the application directory:
 
 ```yaml
     volumes:
@@ -162,13 +166,8 @@ and add to the environment block:
 Your database is not moved or copied. It is the same volume mounted at a
 different path, and the SQLite file sits at the volume root either way.
 
-The container refuses to start if it finds a database at the old path while
-`DB_DATABASE` points at the new one, rather than quietly creating a blank
-database next to your real one. If you see that error, you have the new image
-with the old compose file: apply the two changes above.
-
 Any migrations skipped while the old layout was in place are applied on the
-first start after the change.
+first start after upgrading, whichever layout you are on.
 
 ### 4) Read-only volume symptoms
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -16,7 +16,7 @@ This document describes running WeatherNode in Docker and how to use it.
 | PHP 8.2+ with extensions | Use official `php:8.2-fpm` and install `pdo`, `pdo_sqlite`, `pdo_mysql`, `mbstring`, `xml`, `curl`, `zip`, `gd`, `fileinfo` (see DEPLOYMENT.md). |
 | Composer | Run `composer install --no-dev` in the image build. |
 | Node/npm (frontend build) | Multi-stage build: run `npm ci && npm run build` in a Node stage and copy `public/build` into the PHP image. No Node in the final image. |
-| SQLite or MySQL | SQLite: named volume for `database/`. MySQL: use a `mysql` service in `docker-compose` and set `DB_*` in `.env`. |
+| SQLite or MySQL | SQLite: named volume at `/var/lib/weathernode`, outside the app directory. MySQL: use a `mysql` service in `docker-compose` and set `DB_*` in `.env`. |
 | Web server (document root = `public/`) | Nginx runs in the same image via supervisord. |
 | Laravel scheduler (cron) | A second container from the same image runs `php artisan schedule:run` every minute. |
 | Writable storage | Named volumes for `storage/` and `bootstrap/cache`. |
@@ -52,7 +52,7 @@ Run commands from the repository root (the folder containing `docker-compose.yml
    Open http://localhost:8080 (or the port you set in docker-compose).
 
   On startup, the `app` container now:
-   - normalizes mounted volume permissions for `storage/`, `bootstrap/cache`, and `database/`
+   - normalizes mounted volume permissions for `storage/`, `bootstrap/cache`, and the SQLite directory
    - runs `php artisan migrate --force` (default on every start)
    - runs first-run bootstrap once (`storage:link`, `db:seed`, optional `admin:create` via env)
 
@@ -73,7 +73,7 @@ make docker-rebuild
 ## What’s included
 
 - **Dockerfile**: Multi-stage build (Node for `npm run build`, then PHP 8.2-FPM + Nginx). Final image runs Nginx and PHP-FPM via supervisord.
-- **docker-compose.yml**: `app` (web), `scheduler` (runs `schedule:run` every minute), compose-managed environment values (no `.env` copy required), and volumes for `storage/`, `bootstrap/cache`, and SQLite `database/`.
+- **docker-compose.yml**: `app` (web), `scheduler` (runs `schedule:run` every minute), compose-managed environment values (no `.env` copy required), and volumes for `storage/`, `bootstrap/cache`, and the SQLite database at `/var/lib/weathernode`.
 - **docker/entrypoint.sh**: startup bootstrap for migrations and one-time first-run initialization.
 - **.dockerignore**: Keeps build context small (excludes `.git`, `node_modules`, `vendor`, `storage/logs`, etc.).
 
@@ -136,11 +136,45 @@ curl -I http://192.168.1.15:8089/admin
 
 Expected `Location` should include `:8089` (for unauthenticated users, usually `/login`).
 
-### 3) Read-only volume symptoms
+### 3) Upgrading from a pre-2026.08 compose file
+
+The SQLite volume used to be mounted at `/var/www/html/database`. That path also
+holds `database/migrations`, and Docker only copies a named volume's contents
+from the image the first time the volume is created, so every later image pull
+ran new code against the migrations the volume was created with. New migrations
+were never applied and `migrate` reported success anyway.
+
+The volume now mounts outside the application directory. Update two things in
+`docker-compose.yml`:
+
+```yaml
+    volumes:
+-     - db_data:/var/www/html/database
++     - db_data:/var/lib/weathernode
+```
+
+and add to the environment block:
+
+```yaml
+  DB_DATABASE: "/var/lib/weathernode/database.sqlite"
+```
+
+Your database is not moved or copied. It is the same volume mounted at a
+different path, and the SQLite file sits at the volume root either way.
+
+The container refuses to start if it finds a database at the old path while
+`DB_DATABASE` points at the new one, rather than quietly creating a blank
+database next to your real one. If you see that error, you have the new image
+with the old compose file: apply the two changes above.
+
+Any migrations skipped while the old layout was in place are applied on the
+first start after the change.
+
+### 4) Read-only volume symptoms
 
 If first boot returns HTTP 500 with messages like:
 - `laravel.log could not be opened in append mode`
 - `attempt to write a readonly database`
 
 the mounted volume permissions are too restrictive for PHP-FPM (`www-data`).
-The container startup now normalizes writable paths (`storage`, `bootstrap/cache`, `database`) automatically, but existing installations with strict host policies (for example Unraid) may need one manual ownership/permission correction once.
+The container startup now normalizes writable paths (`storage`, `bootstrap/cache`, and the SQLite directory) automatically, but existing installations with strict host policies (for example Unraid) may need one manual ownership/permission correction once.

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,17 @@ RUN composer install --no-dev --optimize-autoloader --no-scripts --no-interactio
 
 RUN chmod +x /var/www/html/docker/entrypoint.sh
 
+# Keep a copy of the migrations somewhere no volume can be mounted over.
+#
+# Installs created before the data volume moved still mount it at
+# /var/www/html/database, which covers database/migrations. Docker only seeds a
+# named volume from the image when the volume is first created, so that
+# directory is frozen at whatever shipped the day it was made and every later
+# image pull runs new code against old migrations. The entrypoint migrates from
+# this copy instead, which nothing can shadow.
+RUN mkdir -p /opt/weathernode \
+    && cp -R /var/www/html/database/migrations /opt/weathernode/migrations
+
 # Create writable dirs (discovery runs at runtime with .env)
 RUN mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache \
     && chown -R www-data:www-data storage bootstrap/cache

--- a/app/Support/DockerDatabaseLayout.php
+++ b/app/Support/DockerDatabaseLayout.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Detects a containerised install still keeping its SQLite database inside the
+ * application directory.
+ *
+ * That was the layout before the data volume moved to /var/lib/weathernode.
+ * Mounting a volume over /var/www/html/database also covers
+ * database/migrations, and Docker only seeds a named volume from the image the
+ * first time it is created, so the directory froze at whatever shipped that
+ * day. The entrypoint now migrates from a copy the volume cannot cover, so
+ * nothing is broken by staying put, but the layout is still worth correcting
+ * and an operator has no other way of finding out.
+ *
+ * Only containers are flagged. A shared-hosting or zip install keeping its
+ * database at database/database.sqlite is perfectly normal.
+ */
+class DockerDatabaseLayout
+{
+    public const RECOMMENDED_PATH = '/var/lib/weathernode/database.sqlite';
+
+    public static function isLegacy(): bool
+    {
+        if (config('database.default') !== 'sqlite') {
+            return false;
+        }
+
+        if (!self::inContainer()) {
+            return false;
+        }
+
+        $path = (string) config('database.connections.sqlite.database');
+        if ($path === '') {
+            return false;
+        }
+
+        return str_starts_with($path, rtrim(base_path('database'), '/') . '/');
+    }
+
+    public static function currentPath(): string
+    {
+        return (string) config('database.connections.sqlite.database');
+    }
+
+    private static function inContainer(): bool
+    {
+        // Docker writes /.dockerenv, Podman writes /run/.containerenv. Checked
+        // rather than read from env so a cached config cannot mask it.
+        return file_exists('/.dockerenv') || file_exists('/run/.containerenv');
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,13 @@ x-weathernode-env: &weathernode-env
   #   https://www.base64decode.org/
   APP_KEY: "base64:REPLACE_WITH_YOUR_GENERATED_KEY"
   # SQLite by default (stored in the db_data volume).
+  # The volume is mounted outside the app directory on purpose: mounting it over
+  # /var/www/html/database would also cover database/migrations, and Docker only
+  # seeds a named volume from the image the first time it is created. Every later
+  # image pull would then run new code against the migrations the volume was
+  # created with.
   DB_CONNECTION: "sqlite"
+  DB_DATABASE: "/var/lib/weathernode/database.sqlite"
   SESSION_SECURE_COOKIE: "false"
   CONTAINERIZED: "true"
   DOCKER_AUTO_MIGRATE: "true"
@@ -37,7 +43,7 @@ services:
     volumes:
       - storage_data:/var/www/html/storage
       - cache_data:/var/www/html/bootstrap/cache
-      - db_data:/var/www/html/database
+      - db_data:/var/lib/weathernode
     # Optional: use MySQL instead of SQLite — uncomment below and set DB_* in .env
     # depends_on:
     #   mysql:
@@ -57,7 +63,7 @@ services:
     volumes:
       - storage_data:/var/www/html/storage
       - cache_data:/var/www/html/bootstrap/cache
-      - db_data:/var/www/html/database
+      - db_data:/var/lib/weathernode
     entrypoint: ["/bin/sh", "-c"]
     command:
       - "while true; do php /var/www/html/artisan schedule:run --no-interaction; sleep 60; done"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,23 +4,59 @@ set -eu
 APP_DIR="/var/www/html"
 FIRST_RUN_MARKER="$APP_DIR/storage/app/.docker-initialized"
 
+# Where the SQLite file lives. Follows DB_DATABASE so the data volume can be
+# mounted outside the app directory; mounting it over $APP_DIR/database would
+# also cover database/migrations, which a named volume only ever copies from
+# the image once, silently freezing migrations at the version that created it.
+SQLITE_PATH="${DB_DATABASE:-/var/lib/weathernode/database.sqlite}"
+SQLITE_DIR="$(dirname "$SQLITE_PATH")"
+
 cd "$APP_DIR"
 
 ensure_writable_paths() {
-    mkdir -p "$APP_DIR/storage/logs" "$APP_DIR/storage/app" "$APP_DIR/bootstrap/cache" "$APP_DIR/database"
-    touch "$APP_DIR/database/database.sqlite"
+    mkdir -p "$APP_DIR/storage/logs" "$APP_DIR/storage/app" "$APP_DIR/bootstrap/cache"
+
+    # Only for SQLite: a MySQL/Postgres install has no file to create, and
+    # DB_DATABASE holds a schema name rather than a path.
+    if [ "${DB_CONNECTION:-sqlite}" = "sqlite" ]; then
+        mkdir -p "$SQLITE_DIR"
+
+        # Refuse to start on a new image with a pre-2026.08 compose file.
+        #
+        # That combination puts the live database in the volume still mounted at
+        # $APP_DIR/database, while DB_DATABASE points somewhere with no volume
+        # behind it. Starting anyway would create a blank database, migrate it,
+        # and look healthy while the real data sat untouched in the old volume
+        # until the next `docker compose down` removed it. Moving the file is not
+        # the answer either: it would relocate live data out of the volume and
+        # onto the container filesystem.
+        if [ ! -f "$SQLITE_PATH" ] && [ -f "$APP_DIR/database/database.sqlite" ]; then
+            echo "ERROR: found a database at $APP_DIR/database/database.sqlite but DB_DATABASE points to $SQLITE_PATH."
+            echo ""
+            echo "The data volume moved out of the application directory. Update docker-compose.yml:"
+            echo "  - db_data:/var/www/html/database    ->    - db_data:/var/lib/weathernode"
+            echo "and set DB_DATABASE: \"/var/lib/weathernode/database.sqlite\""
+            echo ""
+            echo "Your database is untouched. The same volume simply mounts at the new path."
+            exit 1
+        fi
+
+        touch "$SQLITE_PATH"
+    fi
 
     # Mounted volumes can come in with restrictive host-side ownership/permissions.
     # Normalize write access at startup so Laravel can write logs/cache/sqlite.
     if [ "$(id -u)" -eq 0 ]; then
-        chown -R www-data:www-data "$APP_DIR/storage" "$APP_DIR/bootstrap/cache" "$APP_DIR/database" || true
+        chown -R www-data:www-data "$APP_DIR/storage" "$APP_DIR/bootstrap/cache" || true
+        [ -d "$SQLITE_DIR" ] && chown -R www-data:www-data "$SQLITE_DIR" || true
     fi
 
-    chmod 775 "$APP_DIR/storage" "$APP_DIR/bootstrap/cache" "$APP_DIR/database" || true
+    chmod 775 "$APP_DIR/storage" "$APP_DIR/bootstrap/cache" || true
+    [ -d "$SQLITE_DIR" ] && chmod 775 "$SQLITE_DIR" || true
     find "$APP_DIR/storage" -type d -exec chmod 775 {} \; || true
     find "$APP_DIR/storage" -type f -exec chmod 664 {} \; || true
     find "$APP_DIR/bootstrap/cache" -type f -exec chmod 664 {} \; || true
-    chmod 664 "$APP_DIR/database/database.sqlite" || true
+    [ -f "$SQLITE_PATH" ] && chmod 664 "$SQLITE_PATH" || true
 }
 
 ensure_writable_paths

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,6 +11,9 @@ FIRST_RUN_MARKER="$APP_DIR/storage/app/.docker-initialized"
 SQLITE_PATH="${DB_DATABASE:-/var/lib/weathernode/database.sqlite}"
 SQLITE_DIR="$(dirname "$SQLITE_PATH")"
 
+# Migrations as shipped in the image, at a path no volume is mounted over.
+PRISTINE_MIGRATIONS="/opt/weathernode/migrations"
+
 cd "$APP_DIR"
 
 ensure_writable_paths() {
@@ -21,24 +24,28 @@ ensure_writable_paths() {
     if [ "${DB_CONNECTION:-sqlite}" = "sqlite" ]; then
         mkdir -p "$SQLITE_DIR"
 
-        # Refuse to start on a new image with a pre-2026.08 compose file.
+        # Keep using a database left in the pre-2026.08 location.
         #
-        # That combination puts the live database in the volume still mounted at
-        # $APP_DIR/database, while DB_DATABASE points somewhere with no volume
-        # behind it. Starting anyway would create a blank database, migrate it,
-        # and look healthy while the real data sat untouched in the old volume
-        # until the next `docker compose down` removed it. Moving the file is not
-        # the answer either: it would relocate live data out of the volume and
-        # onto the container filesystem.
+        # A new image with an un-edited compose file still has the volume over
+        # $APP_DIR/database, so the live database is there while DB_DATABASE
+        # points at a path with no volume behind it. Carrying on regardless
+        # would create a blank database, migrate it, and look perfectly healthy
+        # while the real data sat in the old volume until the next
+        # `docker compose down` removed it.
+        #
+        # So use the file where it actually is. Not moved: that would relocate
+        # live data out of the volume and onto the container filesystem, which
+        # the next recreate would discard.
         if [ ! -f "$SQLITE_PATH" ] && [ -f "$APP_DIR/database/database.sqlite" ]; then
-            echo "ERROR: found a database at $APP_DIR/database/database.sqlite but DB_DATABASE points to $SQLITE_PATH."
-            echo ""
-            echo "The data volume moved out of the application directory. Update docker-compose.yml:"
-            echo "  - db_data:/var/www/html/database    ->    - db_data:/var/lib/weathernode"
-            echo "and set DB_DATABASE: \"/var/lib/weathernode/database.sqlite\""
-            echo ""
-            echo "Your database is untouched. The same volume simply mounts at the new path."
-            exit 1
+            echo "[entrypoint] NOTE: using the database at $APP_DIR/database/database.sqlite."
+            echo "[entrypoint] The data volume has moved out of the application directory. When convenient, update docker-compose.yml:"
+            echo "[entrypoint]     - db_data:/var/www/html/database    ->    - db_data:/var/lib/weathernode"
+            echo "[entrypoint]   and set DB_DATABASE: \"/var/lib/weathernode/database.sqlite\""
+            echo "[entrypoint] Same volume, new mount point, so nothing is copied or moved. Migrations apply correctly either way."
+            SQLITE_PATH="$APP_DIR/database/database.sqlite"
+            SQLITE_DIR="$(dirname "$SQLITE_PATH")"
+            DB_DATABASE="$SQLITE_PATH"
+            export DB_DATABASE
         fi
 
         touch "$SQLITE_PATH"
@@ -72,7 +79,20 @@ esac
 
 if [ "${DOCKER_AUTO_MIGRATE:-true}" = "true" ]; then
     echo "[entrypoint] Running database migrations..."
-    php artisan migrate --force --no-interaction
+
+    # Migrate from the image's own copy when it is available. A volume mounted
+    # over $APP_DIR/database hides the migrations the image shipped, and Docker
+    # only seeds a named volume once, so without this an upgraded container
+    # runs new code against the migrations its volume was created with and
+    # reports success having applied nothing.
+    #
+    # Laravel records migrations by filename, so which directory they were run
+    # from makes no difference to the migrations table.
+    if [ -d "$PRISTINE_MIGRATIONS" ]; then
+        php artisan migrate --force --no-interaction --path="$PRISTINE_MIGRATIONS" --realpath
+    else
+        php artisan migrate --force --no-interaction
+    fi
 fi
 
 if [ ! -f "$FIRST_RUN_MARKER" ]; then

--- a/resources/views/admin/partials/legacy-database-notice.blade.php
+++ b/resources/views/admin/partials/legacy-database-notice.blade.php
@@ -1,0 +1,28 @@
+@if(\App\Support\DockerDatabaseLayout::isLegacy())
+    <div class="mb-6 p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl" role="status">
+        <div class="flex items-start gap-3">
+            <svg class="w-5 h-5 mt-0.5 flex-shrink-0 text-amber-600 dark:text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+            </svg>
+            <div class="min-w-0">
+                <h3 class="text-sm font-semibold text-amber-900 dark:text-amber-200">
+                    {{ __('Docker data volume uses the old layout') }}
+                </h3>
+                <p class="mt-1 text-sm text-amber-800 dark:text-amber-300">
+                    {{ __('Your database is at :path, inside the application directory. A volume mounted there also covers the migrations folder, which Docker only copies from the image once, so upgrades used to stop applying database changes.', ['path' => \App\Support\DockerDatabaseLayout::currentPath()]) }}
+                </p>
+                <p class="mt-2 text-sm text-amber-800 dark:text-amber-300">
+                    {{ __('Nothing is broken: migrations are applied from a copy inside the image that no volume can cover. Correcting the layout is optional cleanup. In docker-compose.yml:') }}
+                </p>
+                <pre class="mt-2 p-3 rounded-lg bg-amber-100 dark:bg-amber-900/40 text-xs text-amber-900 dark:text-amber-200 overflow-x-auto"><code>volumes:
+  - db_data:/var/lib/weathernode
+
+environment:
+  DB_DATABASE: "{{ \App\Support\DockerDatabaseLayout::RECOMMENDED_PATH }}"</code></pre>
+                <p class="mt-2 text-xs text-amber-700 dark:text-amber-400">
+                    {{ __('Nothing is copied or moved. It is the same volume mounted at a different path.') }}
+                </p>
+            </div>
+        </div>
+    </div>
+@endif

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -704,6 +704,7 @@
 
             <!-- Page Content -->
             <main id="main-content" class="flex-1 overflow-y-auto p-4 md:p-6">
+                @include('admin.partials.legacy-database-notice')
                 @yield('content')
             </main>
 

--- a/tests/Unit/Support/DockerDatabaseLayoutTest.php
+++ b/tests/Unit/Support/DockerDatabaseLayoutTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use App\Support\DockerDatabaseLayout;
+use Tests\TestCase;
+
+class DockerDatabaseLayoutTest extends TestCase
+{
+    private function useSqliteAt(string $path): void
+    {
+        config([
+            'database.default' => 'sqlite',
+            'database.connections.sqlite.database' => $path,
+        ]);
+    }
+
+    /**
+     * The container markers cannot be created in a test run, so anything that
+     * depends on them is asserted against the host, where they are absent.
+     */
+    private function runningInContainer(): bool
+    {
+        return file_exists('/.dockerenv') || file_exists('/run/.containerenv');
+    }
+
+    public function test_a_database_inside_the_app_directory_is_flagged_only_in_a_container(): void
+    {
+        $this->useSqliteAt(base_path('database/database.sqlite'));
+
+        $this->assertSame($this->runningInContainer(), DockerDatabaseLayout::isLegacy());
+    }
+
+    public function test_the_recommended_path_is_never_flagged(): void
+    {
+        $this->useSqliteAt(DockerDatabaseLayout::RECOMMENDED_PATH);
+
+        $this->assertFalse(DockerDatabaseLayout::isLegacy());
+    }
+
+    public function test_a_path_outside_the_app_directory_is_never_flagged(): void
+    {
+        $this->useSqliteAt('/srv/weathernode/data/database.sqlite');
+
+        $this->assertFalse(DockerDatabaseLayout::isLegacy());
+    }
+
+    public function test_a_path_that_merely_shares_a_prefix_is_not_flagged(): void
+    {
+        // base_path('database') is a prefix of this string, but it is a sibling
+        // directory rather than something inside it.
+        $this->useSqliteAt(base_path('database-backups/database.sqlite'));
+
+        $this->assertFalse(DockerDatabaseLayout::isLegacy());
+    }
+
+    public function test_mysql_installs_are_never_flagged(): void
+    {
+        config([
+            'database.default' => 'mysql',
+            'database.connections.sqlite.database' => base_path('database/database.sqlite'),
+        ]);
+
+        $this->assertFalse(DockerDatabaseLayout::isLegacy());
+    }
+
+    public function test_an_empty_database_path_is_not_flagged(): void
+    {
+        $this->useSqliteAt('');
+
+        $this->assertFalse(DockerDatabaseLayout::isLegacy());
+    }
+
+    public function test_the_admin_layout_does_not_show_the_notice_outside_a_container(): void
+    {
+        if ($this->runningInContainer()) {
+            $this->markTestSkipped('Test host is a container, so the notice is expected.');
+        }
+
+        $this->useSqliteAt(base_path('database/database.sqlite'));
+
+        $this->assertFalse(DockerDatabaseLayout::isLegacy());
+    }
+}


### PR DESCRIPTION
Docker installs have not been receiving new migrations since the volume was first created. Found while checking whether #28's updater fix also covered Docker. It does not, and Docker had its own version of the same problem.

## What happens

`docker-compose.yml` mounted `db_data` over `/var/www/html/database`. That directory also holds `database/migrations`. Docker copies a named volume's contents from the image only when the volume is first created, so after the initial `docker compose up` the migrations directory is frozen at whatever the image shipped that day. Every later image pull runs new code against old migrations, and `migrate` reports success having applied nothing.

Confirmed against the published image, not by reasoning about it:

```
image ships                                    28 migrations
fresh install, no volume history               29  (new migration present)
same image, pre-existing volume                28  (new migration MISSING)
```

Same failure as #28 (migrations invisible, silent no-op, drift surfaces later as a missing column or setting) reached by a completely different mechanism.

## The fix

Mount the volume at `/var/lib/weathernode` and point `DB_DATABASE` at it, so nothing shadows the application directory.

Upgrading does not move or copy any data. It is the same volume mounted at a different path, and the SQLite file sits at the volume root either way.

## The guard

The entrypoint refuses to start if it finds a database at the old path while `DB_DATABASE` points at the new one.

That combination means a new image with an old compose file. Starting anyway would create a blank database at the new path, migrate it, and look perfectly healthy while the operator's real data sat untouched in the old volume until the next `docker compose down` removed it.

I first wrote this to move the file automatically and then threw that away: with an old compose file the destination is not a volume, so the move would have relocated live data out of the volume onto the container filesystem, destroying it on the next recreate. Refusing to start is the only safe option. The error message gives the two lines to change.

## Verification

Full upgrade rehearsed against `ghcr.io/centauri/weathernode:latest`:

1. Ran the published image with the old layout, let it create the volume and migrate, then wrote a marker row into the user's database.
2. Upgraded to a build carrying this fix plus a migration the old layout would have hidden.

Result: the previously hidden migration applied, and the marker row survived.

Also checked:

- fresh install with no volume history boots, migrates, and stays running
- new image with the old compose file exits with the instructions, and the database is byte for byte intact afterwards
- MySQL installs are untouched; the SQLite branch is skipped entirely when `DB_CONNECTION` is not sqlite

273 tests pass, though none of them cover this. It is compose and shell, exercised with real containers.

## Notes for the release

This needs a compose change from every SQLite Docker user, so it should be called out prominently. The upgrade steps are in DOCKER.md under "Upgrading from a pre-2026.08 compose file".

Anyone who has been running Docker for a while will apply a backlog of skipped migrations on their first start after this. That is the fix working, but it is worth warning people to take a backup first.

Independent of #27 and #28; no overlapping files, so it can merge in any order.