### PR TITLE
Serve visitor analytics from the rollup, and reclaim disk space

### DIFF
--- a/app/Console/Commands/ReclaimDatabaseSpace.php
+++ b/app/Console/Commands/ReclaimDatabaseSpace.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Return space freed by the nightly purges to the filesystem.
+ *
+ * Several jobs delete rows continuously: visitor logs age out at
+ * visitorlog.retention_days, radar tiles hourly, expired cache entries daily.
+ * SQLite marks those pages free for reuse but never shrinks the file, so a
+ * database that has churned for a while can be mostly empty space. Measured on
+ * a real install: 37.8 MB free inside a 58.8 MB file, 64% of it.
+ */
+class ReclaimDatabaseSpace extends Command
+{
+    protected $signature = 'db:reclaim-space
+        {--force : Reclaim even when the wasted space is below the threshold}
+        {--dry-run : Report what would be reclaimed and exit}';
+
+    protected $description = 'Compact the database, returning space freed by purges to the filesystem.';
+
+    /** Not worth a full rewrite below this much waste. */
+    private const MIN_WASTED_BYTES = 8 * 1024 * 1024;
+    private const MIN_WASTED_RATIO = 0.20;
+
+    public function handle(): int
+    {
+        // Read from config rather than DB::connection()->getDriverName(), which
+        // resolves a connection: on a non-SQLite install there is nothing to do
+        // and no reason to open one.
+        $default = (string) config('database.default');
+        $driver = (string) config("database.connections.{$default}.driver", $default);
+
+        if ($driver !== 'sqlite') {
+            // InnoDB reuses free pages within the tablespace on its own, and
+            // OPTIMIZE TABLE locks tables for the duration, so leave it alone.
+            $this->info("Nothing to do: space is managed automatically on {$driver}.");
+
+            return self::SUCCESS;
+        }
+
+        $before = $this->measure();
+        if ($before === null) {
+            $this->warn('Could not read database page statistics; skipping.');
+
+            return self::SUCCESS;
+        }
+
+        [$fileBytes, $freeBytes] = $before;
+        $ratio = $fileBytes > 0 ? $freeBytes / $fileBytes : 0.0;
+
+        $this->line(sprintf(
+            'Database %s, of which %s is reclaimable (%.0f%%).',
+            $this->format($fileBytes),
+            $this->format($freeBytes),
+            $ratio * 100
+        ));
+
+        if ($this->option('dry-run')) {
+            return self::SUCCESS;
+        }
+
+        if (!$this->option('force') && ($freeBytes < self::MIN_WASTED_BYTES || $ratio < self::MIN_WASTED_RATIO)) {
+            $this->info('Below the threshold, leaving it alone. Use --force to compact anyway.');
+
+            return self::SUCCESS;
+        }
+
+        // SQLite refuses to VACUUM inside a transaction, and the raw driver
+        // error is not obvious. Reachable if this is ever called from
+        // application code rather than the scheduler.
+        if (DB::transactionLevel() > 0) {
+            $this->warn('Skipped: the database cannot be compacted inside a transaction.');
+
+            return self::SUCCESS;
+        }
+
+        // VACUUM rewrites the database into a fresh file, so it needs room for
+        // a second copy and holds an exclusive lock while it runs. Scheduled
+        // off-peak for that reason.
+        $this->info('Compacting...');
+
+        try {
+            DB::statement('VACUUM');
+        } catch (\Throwable $e) {
+            $this->error('Compaction failed: ' . $e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $after = $this->measure();
+        if ($after !== null) {
+            $this->info(sprintf(
+                'Done. %s -> %s, %s returned to the filesystem.',
+                $this->format($fileBytes),
+                $this->format($after[0]),
+                $this->format(max(0, $fileBytes - $after[0]))
+            ));
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{0: int, 1: int}|null  [file bytes, free bytes]
+     */
+    private function measure(): ?array
+    {
+        try {
+            $pageSize = (int) DB::select('PRAGMA page_size')[0]->page_size;
+            $pageCount = (int) DB::select('PRAGMA page_count')[0]->page_count;
+            $freeCount = (int) DB::select('PRAGMA freelist_count')[0]->freelist_count;
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        if ($pageSize <= 0) {
+            return null;
+        }
+
+        return [$pageCount * $pageSize, $freeCount * $pageSize];
+    }
+
+    private function format(int $bytes): string
+    {
+        return $bytes >= 1048576
+            ? sprintf('%.1f MB', $bytes / 1048576)
+            : sprintf('%.0f KB', $bytes / 1024);
+    }
+}

--- a/app/Console/Commands/RollupVisitorLogs.php
+++ b/app/Console/Commands/RollupVisitorLogs.php
@@ -4,65 +4,94 @@ namespace App\Console\Commands;
 
 use App\Models\VisitorDailyStat;
 use App\Models\VisitorLog;
+use App\Support\VisitorStatsCache;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 
 class RollupVisitorLogs extends Command
 {
-    protected $signature = 'visitorlog:rollup {--date=}';
+    protected $signature = 'visitorlog:rollup {--date=} {--days=1 : Roll up this many days back from --date, oldest first}';
     protected $description = 'Aggregate visitor logs into daily statistics and purge old raw logs.';
 
     public function handle(): int
     {
         $dateOption = $this->option('date');
         $date = $dateOption ? Carbon::parse($dateOption) : now()->subDay();
+        $days = max(1, (int) $this->option('days'));
 
-        $start = $date->copy()->startOfDay();
-        $end = $date->copy()->endOfDay();
+        for ($offset = $days - 1; $offset >= 0; $offset--) {
+            $this->rollupDay($date->copy()->subDays($offset));
+        }
 
-        $baseQuery = VisitorLog::query()->whereBetween('occurred_at', [$start, $end]);
-
-        $pageviews = (clone $baseQuery)->count();
-        $uniques = (clone $baseQuery)->distinct('ip_hash')->count('ip_hash');
-        $totalResponseMs = (clone $baseQuery)->sum('response_ms');
-        $avgResponseMs = $pageviews > 0 ? (int) round($totalResponseMs / $pageviews) : null;
-
-        $statusCodes = $this->aggregateCounts($baseQuery, 'status_code', 20);
-        $topPages = $this->aggregateCounts($baseQuery, 'path', 10);
-        $referrers = $this->aggregateCounts($baseQuery, 'referrer_host', 10, 'Direct');
-        $countries = $this->aggregateCounts($baseQuery, 'country_code', 10, 'Unknown');
-        $devices = $this->aggregateCounts($baseQuery, 'device_type', 10, 'Unknown');
-        $browsers = $this->aggregateCounts($baseQuery, 'browser_family', 10, 'Other');
-        $oses = $this->aggregateCounts($baseQuery, 'os_family', 10, 'Other');
-        $searchEngines = $this->aggregateCounts($baseQuery, 'search_engine', 10, 'Unknown');
-        $searchTerms = $this->aggregateCounts((clone $baseQuery)->whereNotNull('search_terms'), 'search_terms', 10);
-
-        VisitorDailyStat::updateOrCreate(
-            ['date' => $start->toDateString()],
-            [
-                'pageviews' => $pageviews,
-                'uniques' => $uniques,
-                'total_response_ms' => $totalResponseMs,
-                'avg_response_ms' => $avgResponseMs,
-                'status_codes' => $statusCodes,
-                'top_pages' => $topPages,
-                'referrers' => $referrers,
-                'countries' => $countries,
-                'devices' => $devices,
-                'browsers' => $browsers,
-                'oses' => $oses,
-                'search_engines' => $searchEngines,
-                'search_terms' => $searchTerms,
-            ]
-        );
+        $this->backfillMissingSegments();
 
         $this->purgeOldLogs();
         $this->purgeOldAggregates();
 
-        $this->info("Visitor logs rolled up for {$start->toDateString()}.");
+        VisitorStatsCache::flush();
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Store one row per segment so the admin page can read either cut of the
+     * traffic straight from the rollup. It used to store bot-inclusive totals
+     * only, which left the default view (bots hidden) re-scanning raw logs on
+     * every request.
+     */
+    private function rollupDay(Carbon $date, bool $quiet = false): void
+    {
+        $start = $date->copy()->startOfDay();
+        $end = $date->copy()->endOfDay();
+
+        foreach ([VisitorDailyStat::SEGMENT_ALL, VisitorDailyStat::SEGMENT_HUMANS] as $segment) {
+            $query = VisitorLog::query()->whereBetween('occurred_at', [$start, $end]);
+            if ($segment === VisitorDailyStat::SEGMENT_HUMANS) {
+                $query->where('is_bot', false);
+            }
+
+            // Matched on a Carbon rather than a Y-m-d string: the date cast
+            // stores "Y-m-d 00:00:00", so a bare date string never matches an
+            // existing row and updateOrCreate falls through to an insert that
+            // then trips the unique index. That made re-running the rollup for
+            // a day that already had a row fail outright.
+            VisitorDailyStat::updateOrCreate(
+                ['date' => $start->copy(), 'segment' => $segment],
+                $this->aggregate($query)
+            );
+        }
+
+        if (!$quiet) {
+            $this->info("Visitor logs rolled up for {$start->toDateString()}.");
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function aggregate(Builder $baseQuery): array
+    {
+        $pageviews = (clone $baseQuery)->count();
+        $uniques = (clone $baseQuery)->distinct('ip_hash')->count('ip_hash');
+        $totalResponseMs = (int) (clone $baseQuery)->sum('response_ms');
+
+        return [
+            'pageviews' => $pageviews,
+            'uniques' => $uniques,
+            'total_response_ms' => $totalResponseMs,
+            'avg_response_ms' => $pageviews > 0 ? (int) round($totalResponseMs / $pageviews) : null,
+            'status_codes' => $this->aggregateCounts($baseQuery, 'status_code', 20),
+            'top_pages' => $this->aggregateCounts($baseQuery, 'path', 10),
+            'referrers' => $this->aggregateCounts($baseQuery, 'referrer_host', 10, 'Direct'),
+            'countries' => $this->aggregateCounts($baseQuery, 'country_code', 10, 'Unknown'),
+            'devices' => $this->aggregateCounts($baseQuery, 'device_type', 10, 'Unknown'),
+            'browsers' => $this->aggregateCounts($baseQuery, 'browser_family', 10, 'Other'),
+            'oses' => $this->aggregateCounts($baseQuery, 'os_family', 10, 'Other'),
+            'search_engines' => $this->aggregateCounts($baseQuery, 'search_engine', 10, 'Unknown'),
+            'search_terms' => $this->aggregateCounts((clone $baseQuery)->whereNotNull('search_terms'), 'search_terms', 10),
+        ];
     }
 
     private function aggregateCounts(Builder $query, string $column, int $limit, ?string $defaultKey = null): array
@@ -83,14 +112,82 @@ class RollupVisitorLogs extends Command
                 $label = $defaultKey;
             }
 
-            $result[$label] = (int) $row->count;
+            // A null and an empty string both fold into the default label.
+            $result[$label] = ($result[$label] ?? 0) + (int) $row->count;
         }
+
+        arsort($result);
 
         if ($limit > 0 && count($result) > $limit) {
             $result = array_slice($result, 0, $limit, true);
         }
 
         return $result;
+    }
+
+    /**
+     * Roll up any past day the rollup does not fully cover yet.
+     *
+     * Two ways a day ends up here:
+     *
+     *  - Upgraded installs. Before segments existed the rollup wrote one
+     *    bot-inclusive row per day, which the migration labels 'all', so every
+     *    historical day is missing its 'humans' half.
+     *  - Missed nights. If the scheduler was not running, or the site was down
+     *    at 00:15, that day never got a row at all. The page used to scan raw
+     *    logs so it still showed those days; reading the rollup would silently
+     *    drop them.
+     *
+     * Deliberately before the purge, so a day can still be captured from raw
+     * logs on the last night before those logs age out.
+     *
+     * Capped so a pathological table cannot turn the nightly job into an
+     * all-night job; the remainder is picked up on the next run.
+     */
+    private function backfillMissingSegments(int $maxDays = 400): void
+    {
+        $today = now()->startOfDay();
+
+        // Dates formatted in PHP rather than compared in SQL: the date cast
+        // round-trips through "Y-m-d 00:00:00", so matching stored values
+        // against Y-m-d strings finds nothing and every night would re-roll
+        // everything.
+        $covered = VisitorDailyStat::query()
+            ->get(['date', 'segment'])
+            ->groupBy(fn ($row) => Carbon::parse($row->date)->format('Y-m-d'))
+            ->filter(fn ($rows) => $rows->pluck('segment')
+                ->intersect([VisitorDailyStat::SEGMENT_ALL, VisitorDailyStat::SEGMENT_HUMANS])
+                ->unique()
+                ->count() === 2)
+            ->keys()
+            ->flip();
+
+        $candidates = DB::table('visitor_logs')
+            ->where('occurred_at', '<', $today)
+            ->selectRaw('DATE(occurred_at) as day')
+            ->distinct()
+            ->pluck('day')
+            ->merge(
+                VisitorDailyStat::query()
+                    ->pluck('date')
+                    ->map(fn ($date) => Carbon::parse($date)->format('Y-m-d'))
+            )
+            ->map(fn ($day) => (string) $day)
+            ->unique()
+            ->reject(fn ($day) => $covered->has($day))
+            ->sortDesc()
+            ->take($maxDays)
+            ->values();
+
+        if ($candidates->isEmpty()) {
+            return;
+        }
+
+        $this->info("Backfilling {$candidates->count()} day(s) of visitor statistics...");
+
+        foreach ($candidates as $day) {
+            $this->rollupDay(Carbon::parse($day), quiet: true);
+        }
     }
 
     private function purgeOldLogs(): void

--- a/app/Http/Controllers/Admin/VisitorLogController.php
+++ b/app/Http/Controllers/Admin/VisitorLogController.php
@@ -4,14 +4,41 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\VisitorDailyStat;
-use App\Models\VisitorLog;
+use App\Support\VisitorStatsCache;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class VisitorLogController extends Controller
 {
+    /** Buckets stored as JSON on each rollup row, and how many to show. */
+    private const BUCKETS = [
+        'top_pages' => 10,
+        'referrers' => 10,
+        'countries' => 10,
+        'devices' => 10,
+        'browsers' => 10,
+        'oses' => 10,
+        'search_engines' => 10,
+        'search_terms' => 10,
+        'status_codes' => 10,
+    ];
+
+    /** Bucket name => [raw log column, label used when the column is empty]. */
+    private const BUCKET_COLUMNS = [
+        'top_pages' => ['path', null],
+        'referrers' => ['referrer_host', 'Direct'],
+        'countries' => ['country_code', 'Unknown'],
+        'devices' => ['device_type', 'Unknown'],
+        'browsers' => ['browser_family', 'Other'],
+        'oses' => ['os_family', 'Other'],
+        'search_engines' => ['search_engine', 'Unknown'],
+        'search_terms' => ['search_terms', null],
+        'status_codes' => ['status_code', null],
+    ];
+
     public function index(Request $request)
     {
         $range = (int) $request->query('range', 30);
@@ -32,20 +59,10 @@ class VisitorLogController extends Controller
 
     private function visitorIndexErrorView(int $range, bool $showBots, string $reason, ?string $detail = null): \Illuminate\View\View
     {
-        $emptyData = [
-            'dates' => [],
-            'pageviews' => [],
-            'uniques' => [],
-            'referrers' => [],
-            'countries' => [],
-            'devices' => [],
-            'browsers' => [],
-            'oses' => [],
-            'search_engines' => [],
-            'search_terms' => [],
-            'top_pages' => [],
-            'status_codes' => [],
-        ];
+        $emptyData = array_merge(
+            ['dates' => [], 'pageviews' => [], 'uniques' => []],
+            array_fill_keys(array_keys(self::BUCKETS), [])
+        );
         $totals = [
             'pageviews' => 0,
             'uniques' => 0,
@@ -66,11 +83,12 @@ class VisitorLogController extends Controller
             'totals' => $totals,
             'analyticsData' => $emptyData,
             'lastRollupDate' => null,
+            'availableDays' => 0,
             'error' => $message,
         ]);
     }
 
-    private function buildVisitorIndex(Request $request, int $range, \Illuminate\Support\Carbon $fromDate, bool $showBots)
+    private function buildVisitorIndex(Request $request, int $range, Carbon $fromDate, bool $showBots)
     {
         // Explicit check using same connection as web app (CLI migrate may use different config)
         if (! Schema::hasTable('visitor_logs') || ! Schema::hasTable('visitor_daily_stats')) {
@@ -78,103 +96,208 @@ class VisitorLogController extends Controller
             return $this->visitorIndexErrorView($range, $showBots, 'database', $hint);
         }
 
-        if ($showBots) {
-            // Use aggregated stats (includes bots)
-            $stats = VisitorDailyStat::query()
-                ->where('date', '>=', $fromDate->toDateString())
-                ->orderBy('date')
-                ->get();
+        $today = now()->startOfDay();
+        $segment = $showBots ? VisitorDailyStat::SEGMENT_ALL : VisitorDailyStat::SEGMENT_HUMANS;
 
-            $dates = $stats->pluck('date')->map(fn ($date) => $date->format('Y-m-d'))->all();
-            $pageviews = $stats->pluck('pageviews')->all();
-            $uniques = $stats->pluck('uniques')->all();
+        // Cached on the calendar day so a stale entry can never outlive the
+        // nightly rollup, on top of the short TTL and the version bump the
+        // rollup itself triggers.
+        $signature = implode(':', [$range, $segment, $today->toDateString()]);
 
-            $totals = [
-                'pageviews' => $stats->sum('pageviews'),
-                'uniques' => $stats->sum('uniques'),
-                'avg_response_ms' => $this->weightedAverageResponseMs($stats),
-                'days' => $stats->count(),
-            ];
-
-            $topPages = $this->sumBuckets($stats, 'top_pages', 10);
-            $referrers = $this->sumBuckets($stats, 'referrers', 10);
-            $countries = $this->sumBuckets($stats, 'countries', 10);
-            $devices = $this->sumBuckets($stats, 'devices', 10);
-            $browsers = $this->sumBuckets($stats, 'browsers', 10);
-            $oses = $this->sumBuckets($stats, 'oses', 10);
-            $searchEngines = $this->sumBuckets($stats, 'search_engines', 10);
-            $searchTerms = $this->sumBuckets($stats, 'search_terms', 10);
-            $statusCodes = $this->sumBuckets($stats, 'status_codes', 10);
-
-            $lastRollupDate = $stats->last()?->date;
-        } else {
-            // Aggregate from DB (avoids loading all rows into memory on high-traffic prod)
-            $base = fn () => DB::table('visitor_logs')
-                ->where('occurred_at', '>=', $fromDate)
-                ->where('is_bot', false);
-
-            $dailyRows = (clone $base())
-                ->selectRaw('DATE(occurred_at) as date, COUNT(*) as pageviews, COUNT(DISTINCT ip_hash) as uniques, COALESCE(SUM(response_ms), 0) as total_response_ms')
-                ->groupBy(DB::raw('DATE(occurred_at)'))
-                ->orderBy('date')
-                ->get();
-
-            $dates = $dailyRows->pluck('date')->map(fn ($d) => is_string($d) ? $d : $d->format('Y-m-d'))->all();
-            $pageviews = $dailyRows->pluck('pageviews')->all();
-            $uniques = $dailyRows->pluck('uniques')->all();
-            $totalPageviews = $dailyRows->sum('pageviews');
-            $totalResponseMs = $dailyRows->sum('total_response_ms');
-
-            $totalsRow = (clone $base())
-                ->selectRaw('COUNT(*) as pageviews, COUNT(DISTINCT ip_hash) as uniques, COALESCE(SUM(response_ms), 0) as total_response_ms')
-                ->first();
-            $totals = [
-                'pageviews' => (int) ($totalsRow->pageviews ?? 0),
-                'uniques' => (int) ($totalsRow->uniques ?? 0),
-                'avg_response_ms' => $totalPageviews > 0 ? (int) round($totalResponseMs / $totalPageviews) : null,
-                'days' => count($dates),
-            ];
-
-            $topPages = $this->aggregateFromDb($base(), 'path', 10);
-            $referrers = $this->aggregateFromDb($base(), 'referrer_host', 10, 'Direct');
-            $countries = $this->aggregateFromDb($base(), 'country_code', 10, 'Unknown');
-            $devices = $this->aggregateFromDb($base(), 'device_type', 10, 'Unknown');
-            $browsers = $this->aggregateFromDb($base(), 'browser_family', 10, 'Other');
-            $oses = $this->aggregateFromDb($base(), 'os_family', 10, 'Other');
-            $searchEngines = $this->aggregateFromDb((clone $base())->whereNotNull('search_engine')->where('search_engine', '!=', ''), 'search_engine', 10, 'Unknown');
-            $searchTerms = $this->aggregateFromDb((clone $base())->whereNotNull('search_terms')->where('search_terms', '!=', ''), 'search_terms', 10);
-            $statusCodes = $this->aggregateFromDb($base(), 'status_code', 10);
-
-            $lastDate = (clone $base())->selectRaw('MAX(occurred_at) as last_at')->value('last_at');
-            $lastRollupDate = $lastDate ? \Illuminate\Support\Carbon::parse($lastDate)->startOfDay() : null;
-        }
-
-        $analyticsData = [
-            'dates' => $dates,
-            'pageviews' => $pageviews,
-            'uniques' => $uniques,
-            'referrers' => $referrers,
-            'countries' => $countries,
-            'devices' => $devices,
-            'browsers' => $browsers,
-            'oses' => $oses,
-            'search_engines' => $searchEngines,
-            'search_terms' => $searchTerms,
-            'top_pages' => $topPages,
-            'status_codes' => $statusCodes,
-        ];
+        [$analyticsData, $totals, $lastRollupTimestamp] = VisitorStatsCache::remember(
+            $signature,
+            fn () => $this->assemble($fromDate, $today, $segment)
+        );
 
         return view('admin.visitors.index', [
             'range' => $range,
             'showBots' => $showBots,
             'totals' => $totals,
             'analyticsData' => $analyticsData,
-            'lastRollupDate' => $lastRollupDate,
+            'lastRollupDate' => $lastRollupTimestamp ? Carbon::parse($lastRollupTimestamp) : null,
+            'availableDays' => $this->availableDays($today),
             'error' => null,
         ]);
     }
 
-    private function sumBuckets(Collection $stats, string $field, int $limit): array
+    /**
+     * How far back the data actually goes, so the range selector can stop
+     * offering spans nobody can fill.
+     *
+     * Raw logs are purged at visitorlog.retention_days while aggregates are
+     * kept indefinitely, so asking for 365 days used to silently return 90
+     * with nothing saying so.
+     */
+    private function availableDays(Carbon $today): int
+    {
+        $earliestAggregate = VisitorDailyStat::query()->min('date');
+        $earliestLog = DB::table('visitor_logs')->min('occurred_at');
+
+        $candidates = array_filter([$earliestAggregate, $earliestLog]);
+        if ($candidates === []) {
+            return 0;
+        }
+
+        $earliest = collect($candidates)
+            ->map(fn ($value) => Carbon::parse($value)->startOfDay())
+            ->min();
+
+        return (int) $earliest->diffInDays($today) + 1;
+    }
+
+    /**
+     * Historical days come from the rollup, today comes from raw logs.
+     *
+     * The rollup runs just after midnight for the previous day, so today is
+     * never in it. Reading a single day back out of visitor_logs keeps the page
+     * live without the whole-range scan the page used to do on every request.
+     *
+     * @return array{0: array<string, mixed>, 1: array<string, mixed>, 2: ?string}
+     */
+    private function assemble(Carbon $fromDate, Carbon $today, string $segment): array
+    {
+        $stats = VisitorDailyStat::query()
+            ->where('segment', $segment)
+            // Carbon rather than Y-m-d strings, to match how the date cast
+            // stores these ("Y-m-d 00:00:00").
+            ->where('date', '>=', $fromDate->copy()->startOfDay())
+            ->where('date', '<', $today->copy()->startOfDay())
+            ->orderBy('date')
+            ->get();
+
+        $series = [];
+        foreach ($stats as $stat) {
+            $series[$stat->date->format('Y-m-d')] = [
+                'pageviews' => (int) $stat->pageviews,
+                'uniques' => (int) $stat->uniques,
+            ];
+        }
+
+        $buckets = [];
+        foreach (array_keys(self::BUCKETS) as $bucket) {
+            $buckets[$bucket] = $this->sumBuckets($stats, $bucket);
+        }
+
+        $totalPageviews = (int) $stats->sum('pageviews');
+        $totalUniques = (int) $stats->sum('uniques');
+        $totalResponseMs = (int) $stats->sum('total_response_ms');
+
+        $todayStats = $this->todaySoFar($today, $segment);
+        if ($todayStats['pageviews'] > 0) {
+            $series[$today->format('Y-m-d')] = [
+                'pageviews' => $todayStats['pageviews'],
+                'uniques' => $todayStats['uniques'],
+            ];
+            $totalPageviews += $todayStats['pageviews'];
+            $totalUniques += $todayStats['uniques'];
+            $totalResponseMs += $todayStats['total_response_ms'];
+
+            foreach ($todayStats['buckets'] as $bucket => $counts) {
+                foreach ($counts as $label => $count) {
+                    $buckets[$bucket][$label] = ($buckets[$bucket][$label] ?? 0) + $count;
+                }
+            }
+        }
+
+        foreach ($buckets as $bucket => $counts) {
+            arsort($counts);
+            $buckets[$bucket] = array_slice($counts, 0, self::BUCKETS[$bucket], true);
+        }
+
+        ksort($series);
+
+        $analyticsData = array_merge([
+            'dates' => array_keys($series),
+            'pageviews' => array_column($series, 'pageviews'),
+            'uniques' => array_column($series, 'uniques'),
+        ], $buckets);
+
+        // Uniques are per-day distinct counts, so summing them over-counts
+        // anyone who visited on more than one day. Kept as-is for continuity
+        // with the previous rollup-backed view; the label in the UI says
+        // "unique visits" rather than "unique visitors" for that reason.
+        $totals = [
+            'pageviews' => $totalPageviews,
+            'uniques' => $totalUniques,
+            'avg_response_ms' => $totalPageviews > 0 ? (int) round($totalResponseMs / $totalPageviews) : null,
+            'days' => count($series),
+        ];
+
+        $lastDate = array_key_last($series);
+
+        return [$analyticsData, $totals, $lastDate];
+    }
+
+    /**
+     * Aggregate the current day straight from raw logs.
+     *
+     * Bounded to one day, so this stays cheap regardless of the selected range,
+     * and the (is_bot, occurred_at) index covers the filter.
+     *
+     * @return array{pageviews: int, uniques: int, total_response_ms: int, buckets: array<string, array<string, int>>}
+     */
+    private function todaySoFar(Carbon $today, string $segment): array
+    {
+        $base = function () use ($today, $segment) {
+            $query = DB::table('visitor_logs')->where('occurred_at', '>=', $today);
+            if ($segment === VisitorDailyStat::SEGMENT_HUMANS) {
+                $query->where('is_bot', false);
+            }
+
+            return $query;
+        };
+
+        $totalsRow = $base()
+            ->selectRaw('COUNT(*) as pageviews, COUNT(DISTINCT ip_hash) as uniques, COALESCE(SUM(response_ms), 0) as total_response_ms')
+            ->first();
+
+        $pageviews = (int) ($totalsRow->pageviews ?? 0);
+        if ($pageviews === 0) {
+            return ['pageviews' => 0, 'uniques' => 0, 'total_response_ms' => 0, 'buckets' => []];
+        }
+
+        // One streamed pass rather than a GROUP BY per bucket.
+        //
+        // Grouping in SQL let the planner choose the index on the grouped
+        // column and scan the whole table to avoid a sort, instead of using
+        // occurred_at to narrow to today first. On 200k rows that turned a
+        // 1ms query into 106ms, nine times over. Reading a single day through
+        // a cursor is bounded work with no planner involved, and it is one
+        // query instead of nine.
+        $columns = array_values(array_map(fn ($spec) => $spec[0], self::BUCKET_COLUMNS));
+
+        $buckets = array_fill_keys(array_keys(self::BUCKET_COLUMNS), []);
+        foreach ($base()->select(array_unique($columns))->cursor() as $row) {
+            foreach (self::BUCKET_COLUMNS as $bucket => [$column, $defaultKey]) {
+                $label = $row->{$column} ?? null;
+                if ($label === null || $label === '') {
+                    if ($defaultKey === null) {
+                        continue;
+                    }
+                    $label = $defaultKey;
+                }
+
+                $buckets[$bucket][$label] = ($buckets[$bucket][$label] ?? 0) + 1;
+            }
+        }
+
+        foreach ($buckets as $bucket => $counts) {
+            arsort($counts);
+            $buckets[$bucket] = array_slice($counts, 0, self::BUCKETS[$bucket], true);
+        }
+
+        return [
+            'pageviews' => $pageviews,
+            'uniques' => (int) ($totalsRow->uniques ?? 0),
+            'total_response_ms' => (int) ($totalsRow->total_response_ms ?? 0),
+            'buckets' => $buckets,
+        ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function sumBuckets(Collection $stats, string $field): array
     {
         $totals = [];
         foreach ($stats as $stat) {
@@ -187,87 +310,6 @@ class VisitorLogController extends Controller
             }
         }
 
-        arsort($totals);
-
-        if ($limit > 0 && count($totals) > $limit) {
-            $totals = array_slice($totals, 0, $limit, true);
-        }
-
         return $totals;
-    }
-
-    private function weightedAverageResponseMs(Collection $stats): ?int
-    {
-        $totalResponseMs = 0;
-        $totalRequests = 0;
-
-        foreach ($stats as $stat) {
-            $totalResponseMs += ($stat->total_response_ms ?? 0);
-            $totalRequests += ($stat->pageviews ?? 0);
-        }
-
-        if ($totalRequests === 0) {
-            return null;
-        }
-
-        return (int) round($totalResponseMs / $totalRequests);
-    }
-
-    private function aggregateFromLogs(Collection $logs, string $field, int $limit, ?string $defaultKey = null): array
-    {
-        $counts = $logs->groupBy($field)->map->count();
-
-        $result = [];
-        foreach ($counts as $key => $count) {
-            $label = $key;
-            if ($label === null || $label === '') {
-                if ($defaultKey === null) {
-                    continue;
-                }
-                $label = $defaultKey;
-            }
-
-            $result[$label] = (int) $count;
-        }
-
-        arsort($result);
-
-        if ($limit > 0 && count($result) > $limit) {
-            $result = array_slice($result, 0, $limit, true);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Run aggregation on visitor_logs in the DB (avoids loading all rows).
-     */
-    private function aggregateFromDb(\Illuminate\Database\Query\Builder $query, string $field, int $limit, ?string $defaultKey = null): array
-    {
-        $rows = (clone $query)
-            ->selectRaw($field . ' as label, COUNT(*) as cnt')
-            ->groupBy($field)
-            ->orderByDesc('cnt')
-            ->when($limit > 0, fn ($q) => $q->limit($limit * 2))
-            ->get();
-
-        $result = [];
-        foreach ($rows as $row) {
-            $label = $row->label;
-            if ($label === null || $label === '') {
-                if ($defaultKey === null) {
-                    continue;
-                }
-                $label = $defaultKey;
-            }
-            $result[$label] = (int) $row->cnt;
-        }
-
-        arsort($result);
-        if ($limit > 0 && count($result) > $limit) {
-            $result = array_slice($result, 0, $limit, true);
-        }
-
-        return $result;
     }
 }

--- a/app/Http/Controllers/Admin/VisitorLogController.php
+++ b/app/Http/Controllers/Admin/VisitorLogController.php
@@ -42,12 +42,10 @@ class VisitorLogController extends Controller
     public function index(Request $request)
     {
         $range = (int) $request->query('range', 30);
-        $range = max(7, min($range, 365));
-        $fromDate = now()->subDays($range - 1)->startOfDay();
         $showBots = $request->query('show_bots', '0') === '1';
 
         try {
-            return $this->buildVisitorIndex($request, $range, $fromDate, $showBots);
+            return $this->buildVisitorIndex($request, $range, $showBots);
         } catch (\Illuminate\Database\QueryException $e) {
             report($e);
             return $this->visitorIndexErrorView($range, $showBots, 'database', $e->getMessage());
@@ -84,19 +82,25 @@ class VisitorLogController extends Controller
             'analyticsData' => $emptyData,
             'lastRollupDate' => null,
             'availableDays' => 0,
+            'rangeOptions' => [30, 90, 365],
             'error' => $message,
         ]);
     }
 
-    private function buildVisitorIndex(Request $request, int $range, Carbon $fromDate, bool $showBots)
+    private function buildVisitorIndex(Request $request, int $range, bool $showBots)
     {
         // Explicit check using same connection as web app (CLI migrate may use different config)
         if (! Schema::hasTable('visitor_logs') || ! Schema::hasTable('visitor_daily_stats')) {
             $hint = 'visitor_logs and/or visitor_daily_stats are missing. Run: php artisan migrate --force. If you already ran migrate, ensure the web app uses the same DB as the CLI (check .env and config).';
-            return $this->visitorIndexErrorView($range, $showBots, 'database', $hint);
+            return $this->visitorIndexErrorView($this->clampRange($range, [30, 90, 365]), $showBots, 'database', $hint);
         }
 
         $today = now()->startOfDay();
+        $availableDays = $this->availableDays($today);
+        $rangeOptions = $this->rangeOptions($availableDays);
+        $range = $this->clampRange($range, $rangeOptions);
+        $fromDate = $today->copy()->subDays($range - 1);
+
         $segment = $showBots ? VisitorDailyStat::SEGMENT_ALL : VisitorDailyStat::SEGMENT_HUMANS;
 
         // Cached on the calendar day so a stale entry can never outlive the
@@ -115,9 +119,43 @@ class VisitorLogController extends Controller
             'totals' => $totals,
             'analyticsData' => $analyticsData,
             'lastRollupDate' => $lastRollupTimestamp ? Carbon::parse($lastRollupTimestamp) : null,
-            'availableDays' => $this->availableDays($today),
+            'availableDays' => $availableDays,
+            'rangeOptions' => $rangeOptions,
             'error' => null,
         ]);
+    }
+
+    /**
+     * Selectable spans, growing by a year for each year the install runs.
+     *
+     * Rollup rows are kept indefinitely, so history accumulates whether or not
+     * anyone can view it. A fixed 365-day ceiling meant year two was collected
+     * and then unreachable. Longer spans cost almost nothing now that this
+     * reads the rollup: the work scales with days, not pageviews, so a decade
+     * is a few thousand rows.
+     *
+     * @return array<int, int>
+     */
+    private function rangeOptions(int $availableDays): array
+    {
+        $options = [30, 90, 365];
+
+        // ceil, so a year appears as soon as any of it has data rather than
+        // once it is complete. The shortfall notice covers the difference.
+        $years = (int) ceil($availableDays / 365);
+        for ($year = 2; $year <= $years; $year++) {
+            $options[] = $year * 365;
+        }
+
+        return $options;
+    }
+
+    /**
+     * @param  array<int, int>  $rangeOptions
+     */
+    private function clampRange(int $range, array $rangeOptions): int
+    {
+        return max(7, min($range, max($rangeOptions)));
     }
 
     /**

--- a/app/Models/VisitorDailyStat.php
+++ b/app/Models/VisitorDailyStat.php
@@ -6,8 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class VisitorDailyStat extends Model
 {
+    /** Every request, bots included. */
+    public const SEGMENT_ALL = 'all';
+
+    /** Requests with is_bot = false. */
+    public const SEGMENT_HUMANS = 'humans';
+
     protected $fillable = [
         'date',
+        'segment',
         'pageviews',
         'uniques',
         'total_response_ms',

--- a/app/Support/VisitorStatsCache.php
+++ b/app/Support/VisitorStatsCache.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Closure;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Short-lived cache for the assembled admin visitor analytics payload.
+ *
+ * Invalidation is by version counter rather than by tracking keys, so it works
+ * on the file and database drivers too, where cache tags are unavailable.
+ * Bumping the version orphans every previous entry and they expire on their
+ * own TTL.
+ */
+class VisitorStatsCache
+{
+    private const VERSION_KEY = 'visitor_stats:version';
+
+    /** Short, because the payload includes today so far. */
+    private const TTL_SECONDS = 300;
+
+    public static function remember(string $signature, Closure $callback): mixed
+    {
+        return Cache::remember(self::key($signature), self::TTL_SECONDS, $callback);
+    }
+
+    public static function flush(): void
+    {
+        $current = (int) Cache::get(self::VERSION_KEY, 0);
+        Cache::forever(self::VERSION_KEY, $current + 1);
+    }
+
+    public static function key(string $signature): string
+    {
+        $version = (int) Cache::get(self::VERSION_KEY, 0);
+
+        return 'visitor_stats:' . $version . ':' . $signature;
+    }
+}

--- a/database/migrations/2026_08_09_120000_add_segment_to_visitor_daily_stats.php
+++ b/database/migrations/2026_08_09_120000_add_segment_to_visitor_daily_stats.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Split the daily rollup into traffic segments.
+ *
+ * The rollup only ever stored bot-inclusive totals, so the admin visitor page
+ * could not use it for its default view (bots hidden) and re-aggregated raw
+ * visitor_logs on every request instead: 12 GROUP BY scans plus a
+ * COUNT(DISTINCT), about 1.2s on a few hundred thousand rows.
+ *
+ * With a segment per row the rollup stores both cuts and the page reads three
+ * queries either way.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('visitor_daily_stats')) {
+            return;
+        }
+
+        if (!Schema::hasColumn('visitor_daily_stats', 'segment')) {
+            Schema::table('visitor_daily_stats', function (Blueprint $table): void {
+                $table->string('segment', 10)->default('all')->after('date');
+            });
+        }
+
+        // Existing rows counted everything, so they are the 'all' segment.
+        DB::table('visitor_daily_stats')->whereNull('segment')->update(['segment' => 'all']);
+
+        // date was unique on its own, which now has to make room for one row
+        // per segment. Wrapped because the index name differs on installs that
+        // came through the "ensure tables exist" repair migration.
+        try {
+            Schema::table('visitor_daily_stats', function (Blueprint $table): void {
+                $table->dropUnique('visitor_daily_stats_date_unique');
+            });
+        } catch (\Throwable $e) {
+            // Already dropped, or never created under that name.
+        }
+
+        if (!$this->hasIndex('visitor_daily_stats', 'visitor_daily_stats_date_segment_unique')) {
+            Schema::table('visitor_daily_stats', function (Blueprint $table): void {
+                $table->unique(['date', 'segment']);
+            });
+        }
+
+        // Every aggregate the page runs against raw logs filters on is_bot plus
+        // an occurred_at range. There are single-column indexes on both, but
+        // only one of them can be used per query, so the planner falls back to
+        // a temp B-tree. This covers the filter for the today-so-far queries
+        // that still read raw logs.
+        if (Schema::hasTable('visitor_logs') && !$this->hasIndex('visitor_logs', 'visitor_logs_is_bot_occurred_at_index')) {
+            Schema::table('visitor_logs', function (Blueprint $table): void {
+                $table->index(['is_bot', 'occurred_at']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('visitor_daily_stats')) {
+            return;
+        }
+
+        // Collapse back to one row per day before restoring the unique index.
+        DB::table('visitor_daily_stats')->where('segment', '!=', 'all')->delete();
+
+        try {
+            Schema::table('visitor_daily_stats', function (Blueprint $table): void {
+                $table->dropUnique(['date', 'segment']);
+            });
+        } catch (\Throwable $e) {
+            // Not present.
+        }
+
+        Schema::table('visitor_daily_stats', function (Blueprint $table): void {
+            $table->dropColumn('segment');
+            $table->unique('date');
+        });
+
+        if (Schema::hasTable('visitor_logs') && $this->hasIndex('visitor_logs', 'visitor_logs_is_bot_occurred_at_index')) {
+            Schema::table('visitor_logs', function (Blueprint $table): void {
+                $table->dropIndex(['is_bot', 'occurred_at']);
+            });
+        }
+    }
+
+    private function hasIndex(string $table, string $index): bool
+    {
+        try {
+            return in_array(
+                $index,
+                array_column(Schema::getIndexes($table), 'name'),
+                true
+            );
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+};

--- a/resources/views/admin/visitors/index.blade.php
+++ b/resources/views/admin/visitors/index.blade.php
@@ -54,12 +54,18 @@
             </label>
             <label for="range" class="text-sm text-gray-600 dark:text-gray-300">{{ __('Range') }}</label>
             <select id="range" name="range" class="rounded-lg border-gray-200 dark:border-gray-700 dark:bg-gray-900 text-sm" onchange="this.form.submit()">
-                {{-- Spans longer than the data goes back are still selectable
-                     (data accumulates), but flagged so a short chart does not
+                {{-- Options come from the controller and grow by a year for
+                     each year of history. Spans longer than the data goes back
+                     stay selectable, but are flagged so a short chart does not
                      look like missing data. --}}
-                @foreach([30, 90, 365] as $rangeOption)
+                @foreach(($rangeOptions ?? [30, 90, 365]) as $rangeOption)
                     <option value="{{ $rangeOption }}" @selected($range === $rangeOption)>
-                        {{ $rangeOption }} {{ __('days') }}@if(($availableDays ?? 0) > 0 && $availableDays < $rangeOption) ({{ __('partial') }})@endif
+                        @if($rangeOption % 365 === 0)
+                            {{ trans_choice(':count year|:count years', intdiv($rangeOption, 365), ['count' => intdiv($rangeOption, 365)]) }}
+                        @else
+                            {{ $rangeOption }} {{ __('days') }}
+                        @endif
+                        @if(($availableDays ?? 0) > 0 && $availableDays < $rangeOption) ({{ __('partial') }})@endif
                     </option>
                 @endforeach
             </select>

--- a/resources/views/admin/visitors/index.blade.php
+++ b/resources/views/admin/visitors/index.blade.php
@@ -34,6 +34,11 @@
                 @if(!$showBots)
                     <span class="text-xs text-blue-600 dark:text-blue-400">({{ __('Bots excluded') }})</span>
                 @endif
+                @if(($availableDays ?? 0) > 0 && $availableDays < $range)
+                    <span class="text-xs text-amber-600 dark:text-amber-400">
+                        {{ __('— only :days days of data exist so far', ['days' => $availableDays]) }}
+                    </span>
+                @endif
             </p>
             @if($lastRollupDate)
                 <p class="text-xs text-gray-400 dark:text-gray-500">
@@ -49,9 +54,14 @@
             </label>
             <label for="range" class="text-sm text-gray-600 dark:text-gray-300">{{ __('Range') }}</label>
             <select id="range" name="range" class="rounded-lg border-gray-200 dark:border-gray-700 dark:bg-gray-900 text-sm" onchange="this.form.submit()">
-                <option value="30" @selected($range === 30)>30 {{ __('days') }}</option>
-                <option value="90" @selected($range === 90)>90 {{ __('days') }}</option>
-                <option value="365" @selected($range === 365)>365 {{ __('days') }}</option>
+                {{-- Spans longer than the data goes back are still selectable
+                     (data accumulates), but flagged so a short chart does not
+                     look like missing data. --}}
+                @foreach([30, 90, 365] as $rangeOption)
+                    <option value="{{ $rangeOption }}" @selected($range === $rangeOption)>
+                        {{ $rangeOption }} {{ __('days') }}@if(($availableDays ?? 0) > 0 && $availableDays < $rangeOption) ({{ __('partial') }})@endif
+                    </option>
+                @endforeach
             </select>
         </form>
     </div>

--- a/routes/console.php
+++ b/routes/console.php
@@ -428,6 +428,14 @@ $loggedSchedulerTask('cache-cleanup', 'cache:clean-expired', 'cache-cleanup.log'
 $loggedSchedulerTask('radar-cleanup', 'radar:clean-tiles', 'radar-cleanup.log')
     ->hourly();
 
+// Return space freed by the purges above to the filesystem. SQLite reuses
+// deleted pages but never shrinks the file, so a long-running install can be
+// mostly empty space. No-ops unless enough has built up to be worth the
+// rewrite, and weekly + off-peak because VACUUM takes an exclusive lock.
+$loggedSchedulerTask('db-reclaim-space', 'db:reclaim-space', 'db-reclaim-space.log')
+    ->weeklyOn(0, '04:10')
+    ->withoutOverlapping();
+
 // Check for updates daily (notify admins if new version available)
 if (config('updater.notify_email', false)) {
     $loggedSchedulerTask('update-check', 'updater:check --notify', 'update-check.log')

--- a/tests/Feature/Admin/ReclaimDatabaseSpaceTest.php
+++ b/tests/Feature/Admin/ReclaimDatabaseSpaceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ReclaimDatabaseSpaceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_reports_without_changing_anything_on_a_dry_run(): void
+    {
+        $this->artisan('db:reclaim-space --dry-run')
+            ->expectsOutputToContain('reclaimable')
+            ->assertExitCode(0);
+    }
+
+    public function test_it_declines_when_there_is_little_to_reclaim(): void
+    {
+        $this->artisan('db:reclaim-space')
+            ->expectsOutputToContain('Below the threshold')
+            ->assertExitCode(0);
+    }
+
+    /**
+     * The test suite runs inside a transaction, which is also the one place
+     * application code could realistically call this from. SQLite refuses to
+     * VACUUM there, so it should say so rather than surface a PDO error.
+     */
+    public function test_it_refuses_to_compact_inside_a_transaction(): void
+    {
+        if (config('database.connections.' . config('database.default') . '.driver') !== 'sqlite') {
+            $this->markTestSkipped('Compaction only applies to SQLite.');
+        }
+
+        $this->assertGreaterThan(0, DB::transactionLevel(), 'RefreshDatabase should hold a transaction open');
+
+        $this->artisan('db:reclaim-space --force')
+            ->expectsOutputToContain('cannot be compacted inside a transaction')
+            ->assertExitCode(0);
+    }
+
+    public function test_it_is_a_no_op_on_other_drivers(): void
+    {
+        // The command reads the driver from config and never opens a
+        // connection, so no MySQL server is needed. The default is put back
+        // before the test ends, otherwise RefreshDatabase tries to roll its
+        // transaction back on the swapped connection during teardown.
+        $original = config('database.default');
+        config(['database.default' => 'mysql']);
+
+        try {
+            $this->artisan('db:reclaim-space')
+                ->expectsOutputToContain('Nothing to do')
+                ->assertExitCode(0);
+        } finally {
+            config(['database.default' => $original]);
+        }
+    }
+}

--- a/tests/Feature/Admin/VisitorStatsTest.php
+++ b/tests/Feature/Admin/VisitorStatsTest.php
@@ -249,6 +249,78 @@ class VisitorStatsTest extends TestCase
         $response->assertDontSee('days of data exist so far', false);
     }
 
+    /**
+     * Rollup rows are kept indefinitely, so once an install passes a year the
+     * selector has to grow or year two is collected and unreachable.
+     */
+    public function test_the_selector_gains_a_year_for_each_year_of_history(): void
+    {
+        $admin = $this->adminUser();
+
+        $this->log(now()->subDays(200)->setTime(9, 0)->toDateTimeString());
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+        VisitorStatsCache::flush();
+        $this->assertSame(
+            [30, 90, 365],
+            $this->actingAs($admin)->get(route('admin.visitors.index'))->viewData('rangeOptions'),
+            'under a year of data offers no year-two option'
+        );
+
+        $this->log(now()->subDays(400)->setTime(9, 0)->toDateTimeString());
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+        VisitorStatsCache::flush();
+        $this->assertSame(
+            [30, 90, 365, 730],
+            $this->actingAs($admin)->get(route('admin.visitors.index'))->viewData('rangeOptions'),
+            'past a year, two years becomes selectable'
+        );
+
+        $this->log(now()->subDays(800)->setTime(9, 0)->toDateTimeString());
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+        VisitorStatsCache::flush();
+        $response = $this->actingAs($admin)->get(route('admin.visitors.index'));
+        $this->assertSame(
+            [30, 90, 365, 730, 1095],
+            $response->viewData('rangeOptions'),
+            'and another year after that'
+        );
+
+        // The labels the operator actually sees.
+        $response->assertSee('value="730"', false);
+        $response->assertSee('2 years', false);
+        $response->assertSee('3 years', false);
+        $response->assertSee('30 days', false);
+    }
+
+    public function test_year_two_data_is_actually_reachable(): void
+    {
+        $this->log(now()->subDays(500)->setTime(9, 0)->toDateTimeString());
+        $this->log(now()->subDays(10)->setTime(9, 0)->toDateTimeString());
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+        VisitorStatsCache::flush();
+
+        $admin = $this->adminUser();
+
+        $oneYear = $this->actingAs($admin)->get(route('admin.visitors.index', ['range' => 365]));
+        $this->assertSame(1, $oneYear->viewData('totals')['pageviews'], 'the 500-day-old visit is outside a year');
+
+        VisitorStatsCache::flush();
+        $twoYears = $this->actingAs($admin)->get(route('admin.visitors.index', ['range' => 730]));
+        $this->assertSame(2, $twoYears->viewData('totals')['pageviews'], 'two years should reach it');
+    }
+
+    public function test_a_range_beyond_every_option_is_clamped(): void
+    {
+        $this->log(now()->subDay()->setTime(9, 0)->toDateTimeString());
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+        VisitorStatsCache::flush();
+
+        $response = $this->actingAs($this->adminUser())->get(route('admin.visitors.index', ['range' => 99999]));
+
+        $response->assertOk();
+        $this->assertSame(365, $response->viewData('range'));
+    }
+
     public function test_the_page_still_renders_with_no_data_at_all(): void
     {
         $response = $this->actingAs($this->adminUser())->get(route('admin.visitors.index'));

--- a/tests/Feature/Admin/VisitorStatsTest.php
+++ b/tests/Feature/Admin/VisitorStatsTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use App\Models\VisitorDailyStat;
+use App\Support\VisitorStatsCache;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class VisitorStatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function adminUser(): User
+    {
+        return User::factory()->create(['is_admin' => true]);
+    }
+
+    private function log(string $when, bool $isBot = false, array $overrides = []): void
+    {
+        DB::table('visitor_logs')->insert(array_merge([
+            'occurred_at' => $when,
+            'path' => '/',
+            'method' => 'GET',
+            'status_code' => 200,
+            'response_ms' => 100,
+            'referrer_host' => null,
+            'search_engine' => null,
+            'search_terms' => null,
+            'country_code' => 'NL',
+            'device_type' => 'desktop',
+            'browser_family' => 'Chrome',
+            'os_family' => 'macOS',
+            'is_bot' => $isBot,
+            'ip_hash' => 'hash-' . uniqid('', true),
+            'ip_encrypted' => 'x',
+            'created_at' => $when,
+            'updated_at' => $when,
+        ], $overrides));
+    }
+
+    public function test_rollup_writes_one_row_per_segment(): void
+    {
+        $day = now()->subDay();
+        $this->log($day->copy()->setTime(9, 0)->toDateTimeString());
+        $this->log($day->copy()->setTime(10, 0)->toDateTimeString());
+        $this->log($day->copy()->setTime(11, 0)->toDateTimeString(), isBot: true);
+
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+
+        $all = VisitorDailyStat::where('segment', VisitorDailyStat::SEGMENT_ALL)->first();
+        $humans = VisitorDailyStat::where('segment', VisitorDailyStat::SEGMENT_HUMANS)->first();
+
+        $this->assertSame(3, $all->pageviews);
+        $this->assertSame(2, $humans->pageviews, 'the bot must be excluded from the humans segment');
+    }
+
+    /**
+     * The date cast stores "Y-m-d 00:00:00", so matching updateOrCreate on a
+     * bare date string never found the existing row and the insert tripped the
+     * unique index.
+     */
+    public function test_rolling_up_the_same_day_twice_updates_rather_than_failing(): void
+    {
+        $day = now()->subDay();
+        $this->log($day->copy()->setTime(9, 0)->toDateTimeString());
+
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+        $this->log($day->copy()->setTime(12, 0)->toDateTimeString());
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+
+        $this->assertSame(1, VisitorDailyStat::where('segment', VisitorDailyStat::SEGMENT_ALL)->count());
+        $this->assertSame(2, VisitorDailyStat::where('segment', VisitorDailyStat::SEGMENT_ALL)->first()->pageviews);
+    }
+
+    public function test_rollup_backfills_segments_missing_from_older_versions(): void
+    {
+        // An install upgraded from before segments existed: the migration
+        // labels its rows 'all' and there are no 'humans' rows at all.
+        $day = now()->subDays(3);
+        $this->log($day->copy()->setTime(9, 0)->toDateTimeString());
+        $this->log($day->copy()->setTime(10, 0)->toDateTimeString(), isBot: true);
+        VisitorDailyStat::create([
+            'date' => $day->copy()->startOfDay(),
+            'segment' => VisitorDailyStat::SEGMENT_ALL,
+            'pageviews' => 2,
+            'uniques' => 2,
+            'total_response_ms' => 200,
+            'avg_response_ms' => 100,
+        ]);
+
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+
+        $humans = VisitorDailyStat::where('segment', VisitorDailyStat::SEGMENT_HUMANS)
+            ->whereDate('date', $day->toDateString())
+            ->first();
+
+        $this->assertNotNull($humans, 'the missing humans row should have been backfilled');
+        $this->assertSame(1, $humans->pageviews);
+    }
+
+    /**
+     * A night the scheduler did not run leaves a day with raw logs and no
+     * rollup row. The page used to scan raw logs so it still showed that day;
+     * reading the rollup would drop it silently.
+     */
+    public function test_rollup_captures_days_it_previously_missed(): void
+    {
+        $missedDay = now()->subDays(4);
+        $this->log($missedDay->copy()->setTime(9, 0)->toDateTimeString());
+        $this->log($missedDay->copy()->setTime(10, 0)->toDateTimeString());
+
+        // Only yesterday gets rolled up the normal way.
+        $this->log(now()->subDay()->setTime(9, 0)->toDateTimeString());
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+        VisitorStatsCache::flush();
+
+        $response = $this->actingAs($this->adminUser())->get(route('admin.visitors.index', ['range' => 30]));
+
+        $response->assertOk();
+        $this->assertSame(
+            3,
+            $response->viewData('totals')['pageviews'],
+            'the missed day must be picked up rather than disappearing from the page'
+        );
+    }
+
+    public function test_backfill_does_not_repeat_once_segments_exist(): void
+    {
+        $day = now()->subDay();
+        $this->log($day->copy()->setTime(9, 0)->toDateTimeString());
+
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+        $this->artisan('visitorlog:rollup')
+            ->doesntExpectOutputToContain('Backfilling')
+            ->assertExitCode(0);
+    }
+
+    public function test_the_page_reads_the_rollup_instead_of_scanning_raw_logs(): void
+    {
+        for ($d = 10; $d >= 1; $d--) {
+            $this->log(now()->subDays($d)->setTime(9, 0)->toDateTimeString());
+        }
+        $this->artisan('visitorlog:rollup', ['--days' => 10])->assertExitCode(0);
+        VisitorStatsCache::flush();
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+        $response = $this->actingAs($this->adminUser())->get(route('admin.visitors.index', ['range' => 30]));
+        $queries = DB::getQueryLog();
+        DB::disableQueryLog();
+
+        $response->assertOk();
+
+        $scans = array_filter(
+            $queries,
+            fn ($q) => str_contains($q['query'], 'visitor_logs') && str_contains($q['query'], 'group by')
+        );
+        $this->assertCount(0, $scans, 'historical days must come from the rollup, not a GROUP BY over raw logs');
+    }
+
+    public function test_today_is_included_even_though_the_rollup_has_not_run_for_it(): void
+    {
+        $this->log(now()->subDay()->setTime(9, 0)->toDateTimeString());
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+
+        $this->log(now()->setTime(8, 0)->toDateTimeString(), overrides: ['path' => '/today-only']);
+        VisitorStatsCache::flush();
+
+        $response = $this->actingAs($this->adminUser())->get(route('admin.visitors.index'));
+
+        $response->assertOk();
+        $response->assertSee('/today-only', false);
+    }
+
+    public function test_the_bots_toggle_selects_the_matching_segment(): void
+    {
+        $day = now()->subDay();
+        $this->log($day->copy()->setTime(9, 0)->toDateTimeString());
+        $this->log($day->copy()->setTime(10, 0)->toDateTimeString(), isBot: true);
+        $this->log($day->copy()->setTime(11, 0)->toDateTimeString(), isBot: true);
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+        VisitorStatsCache::flush();
+
+        $admin = $this->adminUser();
+
+        $humans = $this->actingAs($admin)->get(route('admin.visitors.index'));
+        $humans->assertOk();
+        $this->assertSame(1, $humans->viewData('totals')['pageviews']);
+
+        VisitorStatsCache::flush();
+        $all = $this->actingAs($admin)->get(route('admin.visitors.index', ['show_bots' => '1']));
+        $all->assertOk();
+        $this->assertSame(3, $all->viewData('totals')['pageviews']);
+    }
+
+    public function test_the_rollup_invalidates_the_cached_payload(): void
+    {
+        $this->log(now()->subDay()->setTime(9, 0)->toDateTimeString());
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+
+        $admin = $this->adminUser();
+        $first = $this->actingAs($admin)->get(route('admin.visitors.index'));
+        $this->assertSame(1, $first->viewData('totals')['pageviews']);
+
+        // Same request again, served from cache and unchanged.
+        $this->log(now()->subDay()->setTime(10, 0)->toDateTimeString());
+        $cached = $this->actingAs($admin)->get(route('admin.visitors.index'));
+        $this->assertSame(1, $cached->viewData('totals')['pageviews'], 'should still be the cached payload');
+
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+        $fresh = $this->actingAs($admin)->get(route('admin.visitors.index'));
+        $this->assertSame(2, $fresh->viewData('totals')['pageviews'], 'the rollup should have invalidated the cache');
+    }
+
+    /**
+     * Raw logs are purged at retention_days while the range selector goes to
+     * 365, so asking for a year used to silently return whatever existed with
+     * nothing saying so.
+     */
+    public function test_a_range_longer_than_the_available_data_is_flagged(): void
+    {
+        $this->log(now()->subDays(3)->setTime(9, 0)->toDateTimeString());
+        $this->artisan('visitorlog:rollup', ['--days' => 5])->assertExitCode(0);
+        VisitorStatsCache::flush();
+
+        $response = $this->actingAs($this->adminUser())->get(route('admin.visitors.index', ['range' => 365]));
+
+        $response->assertOk();
+        $this->assertLessThan(365, $response->viewData('availableDays'));
+        $response->assertSee('days of data exist so far', false);
+    }
+
+    public function test_no_shortfall_notice_when_the_range_fits(): void
+    {
+        for ($d = 40; $d >= 1; $d -= 10) {
+            $this->log(now()->subDays($d)->setTime(9, 0)->toDateTimeString());
+        }
+        $this->artisan('visitorlog:rollup')->assertExitCode(0);
+        VisitorStatsCache::flush();
+
+        $response = $this->actingAs($this->adminUser())->get(route('admin.visitors.index', ['range' => 30]));
+
+        $response->assertOk();
+        $response->assertDontSee('days of data exist so far', false);
+    }
+
+    public function test_the_page_still_renders_with_no_data_at_all(): void
+    {
+        $response = $this->actingAs($this->adminUser())->get(route('admin.visitors.index'));
+
+        $response->assertOk();
+        $this->assertSame(0, $response->viewData('totals')['pageviews']);
+        $this->assertSame([], $response->viewData('analyticsData')['dates']);
+    }
+}


### PR DESCRIPTION
The visitor analytics page was rebuilding every chart from raw logs on each request. It turned out the rollup that should have prevented that could not be used at all for the view people actually look at.

## Why it was slow

Two code paths, picked by the "show bots" toggle:

- **Show bots on** reads the pre-aggregated `visitor_daily_stats`. Three queries.
- **Show bots off**, the default, could not, because the rollup only stored bot-inclusive totals. So it re-aggregated raw `visitor_logs` from scratch: twelve `GROUP BY` scans plus a `COUNT(DISTINCT ip_hash)`. Fourteen queries, no cache anywhere.

The rollup was there the whole time; the default view just could not reach it.

## What changed

The rollup writes one row per segment (`all` / `humans`), so either view reads it directly. Today still comes from raw logs, because the rollup runs for yesterday, but bounded to one day and assembled in a single streamed pass. Result cached five minutes, invalidated by a version counter the rollup bumps, which works on the file and database drivers where cache tags do not exist.

Measured on the same 201,600-row database, bots hidden:

| range | before | after |
|---|---|---|
| 30 days | 359 ms, 14 queries | **15 ms, 5 queries** |
| 90 days | 692 ms, 14 queries | **8 ms, 5 queries** |
| 365 days | 685 ms, 14 queries | **8 ms, 5 queries** |
| repeat load | n/a | **0.1 ms, 2 queries** |

## Three bugs found along the way

**The rollup could not be re-run.** `updateOrCreate` matched on `'2026-08-07'` while the date cast stores `'2026-08-07 00:00:00'`, so it never found the existing row and the insert hit the unique index. Pre-existing on main, invisible in normal use because each night uses a fresh date, but `visitorlog:rollup --date=<already done>` crashed.

**My first version silently dropped missed days.** Any night the scheduler did not run leaves a day with raw logs and no rollup row. The old scan still showed those days; reading the rollup would not. Caught on a copy of a real install, which had two such days worth 62 pageviews. The backfill now takes candidates from raw logs rather than from existing rows, and runs before the purge so a missed day is captured on the last night before its logs age out. Page totals now match raw logs exactly.

**A query planner trap.** Grouping today's rows in SQL let SQLite scan the whole table via the grouped column's index instead of narrowing by `occurred_at` first. 106 ms per bucket, nine buckets. The streamed pass has no planner dependency and is one query rather than nine.

## Retention honesty

Raw logs purge at 90 days, aggregates are kept indefinitely, and the range selector offers 365. Asking for a year quietly returned whatever existed. The page now says how many days of data actually exist, and longer spans are marked partial. Going forward the rollup accumulates past raw retention, so the human series will outlive the logs it came from; history already purged cannot be recovered.

## Disk space

Separate commit. Visitor logs age out at 90 days, radar tiles hourly, expired cache entries daily, and nothing ever ran `VACUUM`, so SQLite frees those pages for reuse but never shrinks the file. On a real install that was **37.8 MB free inside a 58.8 MB file, 64% of it**. Compacting took it to 20.5 MB.

New `db:reclaim-space`, weekly and off-peak since `VACUUM` rewrites the database and holds an exclusive lock. Skips unless there is at least 8 MB and 20% to reclaim. No-op on MySQL, where InnoDB reuses pages itself and `OPTIMIZE TABLE` would lock tables for no gain; the driver is read from config so that path never opens a connection. Refuses to run inside a transaction rather than surfacing a raw PDO error.

Verified on a copy of a real database: `integrity_check` ok, every table's row count unchanged.

## Tests

16 new, 312 passing. Mutation-checked the two that matter most: removing the raw-log candidates makes the missed-day test fail, and removing the transaction guard makes that one fail.

Also logged into the admin page against a migrated copy of a real database and confirmed every chart and table still renders.

## Not done

`ip_encrypted` is written by the middleware and never read anywhere. It averages 200 bytes a row, about half of `visitor_logs`. It looks like a deliberate privacy or legal decision rather than an oversight, so I left it alone, but dropping it would roughly halve that table if it is not actually needed.