### PR TITLE
Fix the release checksum, and stop scheduling the update check twice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,14 +121,18 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           COMMIT="$(git rev-parse --short=16 HEAD)"
           echo "${TAG}" > VERSION
+          # No sha256 field here on purpose: release.json ships inside the zip,
+          # so it can never hold the hash of the archive containing it. It used
+          # to be filled in after hashing and re-added with `zip -u`, which
+          # changed the zip after the hash was taken and left every published
+          # checksum stale. The authoritative hash is the .sha256 asset.
           cat > release.json <<'JSON'
           {
             "name": "WeatherNode",
             "version": "__TAG__",
             "commit": "__COMMIT__",
             "built_at_utc": "__BUILT_AT__",
-            "artifact": "weathernode-deploy.zip",
-            "sha256": ""
+            "artifact": "weathernode-deploy.zip"
           }
           JSON
           BUILT_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
@@ -142,14 +146,15 @@ jobs:
             app bootstrap config database public resources routes storage artisan composer.json composer.lock \
             vendor VERSION release.json
 
-      - name: Compute sha256 and update release.json
+      # Nothing may modify the zip after this point, or the published checksum
+      # stops matching the artifact people download.
+      - name: Compute sha256 of the finished zip
         id: checksum
         run: |
           SHA="$(sha256sum weathernode-deploy.zip | awk '{print $1}')"
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-          sed -i "s/\"sha256\": \"\"/\"sha256\": \"${SHA}\"/" release.json
-          zip -u weathernode-deploy.zip release.json
           printf '%s  weathernode-deploy.zip\n' "${SHA}" > weathernode-deploy.zip.sha256
+          sha256sum -c weathernode-deploy.zip.sha256
 
       - name: Create GitHub Release and upload asset
         uses: softprops/action-gh-release@v2

--- a/routes/console.php
+++ b/routes/console.php
@@ -436,11 +436,11 @@ $loggedSchedulerTask('db-reclaim-space', 'db:reclaim-space', 'db-reclaim-space.l
     ->weeklyOn(0, '04:10')
     ->withoutOverlapping();
 
-// Check for updates daily (notify admins if new version available)
-if (config('updater.notify_email', false)) {
-    $loggedSchedulerTask('update-check', 'updater:check --notify', 'update-check.log')
-        ->dailyAt('02:00');
-}
+// The update check is scheduled unconditionally further up, near the other
+// maintenance tasks. There used to be a second copy here behind
+// updater.notify_email; with that setting on, both ran and admins got two
+// emails a day. The command sends the notification itself when the setting is
+// enabled, so one schedule covers both the banner and the email.
 
 // =============================================================================
 // TELEMETRY (community stations)


### PR DESCRIPTION
Two release-plumbing fixes found while verifying v2026.08.3.

## The published checksum did not match the zip

The workflow hashed the zip, wrote that hash into `release.json`, then re-added it with `zip -u`, changing the archive after it had been hashed:

```yaml
SHA="$(sha256sum weathernode-deploy.zip | ...)"   # hashed here
sed -i "...${SHA}..." release.json
zip -u weathernode-deploy.zip release.json         # zip changed after hashing
printf '%s ...' "${SHA}" > weathernode-deploy.zip.sha256
```

So the `.sha256` asset, the `SHA256:` line in the release body, and the `sha256` field inside `release.json` all carried the pre-modification value. Downloading v2026.08.3 and running `shasum -c` fails, which looks like a corrupted or tampered file.

Checked against the published releases:

| release | body says | asset actually is |
|---|---|---|
| v2026.08.3 | `962fd0e2…` | `53480000…` |
| v2026.08.2 | `7d90618c…` | `1040d38c…` |
| v2026.08.01 | `2f9687ea…` | `29c84f1c…` |

**In-app updates were never affected.** `resolveExpectedZipChecksum()` prefers GitHub's own asset digest, which is computed after upload and is correct; the release body is only the fallback. I verified that before treating this as urgent.

The `sha256` field is dropped from `release.json`, because a file shipped inside the zip can never hold the hash of the archive containing it. Nothing reads it: the only consumer is `VersionService::getReleaseInfo()`, which uses `version` and `commit`. The hash is now taken from the finished artifact and verified in the same step, so any future change that mutates the zip afterwards fails the build instead of shipping a wrong hash.

Reproduced both pipelines locally: the old ordering fails `shasum -c`, the new one passes.

Nothing already released changes. Future tags verify cleanly.

## The update check was scheduled twice

v2026.08.2 added an unconditional daily check to drive the admin banner, but the older conditional one behind `updater.notify_email` was still there. With that setting off, the default, only one registered and nobody noticed. Turn it on and both ran: two checks, two emails a day.

Kept the unconditional one, since the command already sends the notification itself when the setting is on, so one schedule covers the banner and the email.

Verified with `schedule:list`: two entries before with `UPDATER_NOTIFY_EMAIL=true`, one after, and still one with it off.

## Also verified: the Docker migration fix handles this release's new migration

v2026.08.3 shipped a second migration, which made a proper end-to-end test of the #30 fix possible. Installed on **v2026.08.01**, the last release before that fix, so its volume holds that image's 28 migration files and shadows anything newer. Then upgraded straight to v2026.08.3 with the compose file untouched:

```
shadowed database/migrations: 28      <- what the volume still hides behind
pristine /opt copy:           30      <- what the entrypoint migrates from

2026_08_07_090000_add_quick_stats_tile_settings ... DONE
2026_08_09_120000_add_segment_to_visitor_daily_stats ... DONE

applied migrations: 30 (was 28)
segment column live: YES
quick stats tiles rendered: 10
```

Both migrations applied through a volume that still shadows the directory, the container stayed up on HTTP 200, and both features work. That is the exact scenario that silently applied nothing before #30.

315 tests pass. No application code changed here beyond the schedule.