### PR TITLE
Stop chowning the whole app directory on MySQL and Postgres installs

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,13 +8,44 @@ FIRST_RUN_MARKER="$APP_DIR/storage/app/.docker-initialized"
 # mounted outside the app directory; mounting it over $APP_DIR/database would
 # also cover database/migrations, which a named volume only ever copies from
 # the image once, silently freezing migrations at the version that created it.
-SQLITE_PATH="${DB_DATABASE:-/var/lib/weathernode/database.sqlite}"
-SQLITE_DIR="$(dirname "$SQLITE_PATH")"
+#
+# Only meaningful on SQLite. On MySQL and Postgres, DB_DATABASE is a schema
+# name, and DOCKER.md tells people to set DB_DATABASE=weathernode, so this used
+# to leave SQLITE_DIR as `dirname weathernode` = "." — the application
+# directory, since the script cd's there. The ownership fixups below then
+# recursively chowned the whole app, copying every file out of the image layer
+# on overlayfs. Reported as a multi-hour startup with an empty log.
+#
+# Left empty for other drivers. Every consumer is [ -d ] / [ -f ] guarded, so
+# empty makes them all no-ops.
+if [ "${DB_CONNECTION:-sqlite}" = "sqlite" ]; then
+    SQLITE_PATH="${DB_DATABASE:-/var/lib/weathernode/database.sqlite}"
+    SQLITE_DIR="$(dirname "$SQLITE_PATH")"
+else
+    SQLITE_PATH=""
+    SQLITE_DIR=""
+fi
 
 # Migrations as shipped in the image, at a path no volume is mounted over.
 PRISTINE_MIGRATIONS="/opt/weathernode/migrations"
 
 cd "$APP_DIR"
+
+# Recursive chown is expensive on overlayfs, so skip it when the directory is
+# already owned correctly. Checks the directory itself, which is enough for the
+# case this exists for: a volume arriving with restrictive host-side ownership.
+chown_if_needed() {
+    target="$1"
+    [ -d "$target" ] || return 0
+
+    owner="$(stat -c '%U:%G' "$target" 2>/dev/null || echo '')"
+    if [ "$owner" = 'www-data:www-data' ]; then
+        return 0
+    fi
+
+    echo "[entrypoint] Fixing ownership of $target..."
+    chown -R www-data:www-data "$target" || true
+}
 
 ensure_writable_paths() {
     mkdir -p "$APP_DIR/storage/logs" "$APP_DIR/storage/app" "$APP_DIR/bootstrap/cache"
@@ -53,19 +84,27 @@ ensure_writable_paths() {
 
     # Mounted volumes can come in with restrictive host-side ownership/permissions.
     # Normalize write access at startup so Laravel can write logs/cache/sqlite.
+    #
+    # Only ever aimed at volume mounts, never at image content: chown -R against
+    # an image-layer path forces overlayfs to copy every file up into the
+    # container's writable layer, on every recreate.
     if [ "$(id -u)" -eq 0 ]; then
-        chown -R www-data:www-data "$APP_DIR/storage" "$APP_DIR/bootstrap/cache" || true
-        [ -d "$SQLITE_DIR" ] && chown -R www-data:www-data "$SQLITE_DIR" || true
+        chown_if_needed "$APP_DIR/storage"
+        chown_if_needed "$APP_DIR/bootstrap/cache"
+        [ -n "$SQLITE_DIR" ] && chown_if_needed "$SQLITE_DIR"
     fi
 
     chmod 775 "$APP_DIR/storage" "$APP_DIR/bootstrap/cache" || true
-    [ -d "$SQLITE_DIR" ] && chmod 775 "$SQLITE_DIR" || true
+    [ -n "$SQLITE_DIR" ] && [ -d "$SQLITE_DIR" ] && chmod 775 "$SQLITE_DIR" || true
     find "$APP_DIR/storage" -type d -exec chmod 775 {} \; || true
     find "$APP_DIR/storage" -type f -exec chmod 664 {} \; || true
     find "$APP_DIR/bootstrap/cache" -type f -exec chmod 664 {} \; || true
     [ -f "$SQLITE_PATH" ] && chmod 664 "$SQLITE_PATH" || true
 }
 
+# Before any filesystem work, so a stall here shows up in `docker logs` instead
+# of presenting as a container that is Up with an empty log.
+echo "[entrypoint] Preparing filesystem (database driver: ${DB_CONNECTION:-sqlite})..."
 ensure_writable_paths
 
 case "${APP_KEY:-}" in


### PR DESCRIPTION
Fixes #34. My bug, introduced in #30 and shipped in v2026.08.2. The report is accurate in every detail, including the suggested fix.

## What happens

The entrypoint derived the SQLite path from `DB_DATABASE` without checking `DB_CONNECTION`:

```sh
SQLITE_PATH="${DB_DATABASE:-/var/lib/weathernode/database.sqlite}"
SQLITE_DIR="$(dirname "$SQLITE_PATH")"
```

On MySQL, `DB_DATABASE` is a schema name, and DOCKER.md tells people to set `DB_DATABASE=weathernode`. So `SQLITE_DIR` became `dirname weathernode` = `.`, and the script has already `cd`'d to `/var/www/html`, so the ownership fixup recursively chowned the entire application directory.

The `mkdir` block immediately above was already guarded by `DB_CONNECTION` and even carried a comment describing this exact hazard. The ownership block below it was not. I wrote both.

## Reproduced on the published image

```
SQLITE_PATH = [weathernode]
SQLITE_DIR  = [.]
resolves to: /var/www/html
files underneath: 42105
```

Running v2026.08.3 with the documented MySQL settings:

```
container status: running   restarts: 0
docker logs bytes: 0
http: 000 no response
process: chown -R www-data:www-data .
```

26 seconds on this machine before it got past the chown; the reporter saw roughly two hours on a slower disk with a larger image. Same bug, severity scales with storage speed and image size. All of it happens before the entrypoint's first `echo`, which is why it looks like a healthy container that simply says nothing.

## The fix

Leave `SQLITE_PATH` and `SQLITE_DIR` empty for non-SQLite drivers, as suggested in the report. Every consumer is already existence-guarded, so empty values make them all no-ops.

| driver | DB_DATABASE | resolved path | resolved dir |
|---|---|---|---|
| sqlite | `/var/lib/weathernode/database.sqlite` | same | `/var/lib/weathernode` |
| sqlite | unset | default | `/var/lib/weathernode` |
| mysql | `weathernode` | empty | empty |
| pgsql | `weathernode` | empty | empty |

Both adjacent suggestions taken as well:

**A log line before the filesystem work.** An empty `docker logs` on a container reporting `Up` is about the worst possible signal, and it is what made this so hard to diagnose. Now it prints the driver it resolved, so a stall there is visible and self-explanatory.

**Skip the recursive chown when ownership already matches.** It exists for volumes arriving with restrictive host-side ownership, which is a first-boot concern; paying for a copy-up on every recreate is not worth it.

## Verified after the change

MySQL settings, patched image:

```
first log line after 0s: [entrypoint] Preparing filesystem (database driver: mysql)...
                         [entrypoint] Running database migrations...
still chowning the app dir? 0

composer.json owner: root:root          <- image content untouched
vendor/ owner:       root:root          <- untouched
storage/ owner:      www-data:www-data  <- still fixed, as intended
```

SQLite unaffected: HTTP 200, 30 migrations applied, database file and its directory owned by www-data on the volume.

## Note on testing

This is shell in the container entrypoint, and the repo has no harness for that, so it is verified by running real containers rather than by an automated test. The 318 PHP tests still pass but none of them touch this path. If you want, a small shell test script for the driver matrix would be a reasonable follow-up; I did not want to invent a test harness inside an urgent fix.

## Suggested handling

This warrants a patch release fairly promptly. Anyone who followed the MySQL instructions has been paying it on every recreate since v2026.08.2, and `pull_policy: always` in the shipped compose means every image pull triggers a recreate.