### PR TITLE
Fix Ambient Weather credential configuration

### DIFF
--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -660,6 +660,24 @@ class SettingsController extends Controller
             $this->updateLiveDataSettings($request);
         }
 
+        if ($group === 'ambient' && $request->input('ambient_enabled') === '1') {
+            $apiKey = trim((string) $request->input('ambient_api_key', ''))
+                ?: trim((string) Setting::getValue('ambient.api_key', ''));
+            $applicationKey = trim((string) $request->input('ambient_application_key', ''))
+                ?: trim((string) Setting::getValue('ambient.application_key', ''));
+
+            $errors = [];
+            if (empty($apiKey)) {
+                $errors['ambient_api_key'] = 'The Ambient Weather API key is required when the integration is enabled.';
+            }
+            if (empty($applicationKey)) {
+                $errors['ambient_application_key'] = 'The Ambient Weather application key is required when the integration is enabled.';
+            }
+            if ($errors !== []) {
+                throw \Illuminate\Validation\ValidationException::withMessages($errors);
+            }
+        }
+
         if ($group === 'pollen') {
             $this->updatePollenSettings($request);
             Cache::forget('pollen_forecast');

--- a/app/Services/Weather/AmbientWeatherService.php
+++ b/app/Services/Weather/AmbientWeatherService.php
@@ -18,7 +18,7 @@ class AmbientWeatherService
     public function __construct()
     {
         $this->apiKey = $this->getDecryptedValue('ambient.api_key');
-        $this->applicationKey = 'your-application-key'; // Usually a static key
+        $this->applicationKey = $this->getDecryptedValue('ambient.application_key');
         $this->macAddress = Setting::getValue('ambient.mac_address', '');
     }
 
@@ -45,7 +45,7 @@ class AmbientWeatherService
      */
     public function isConfigured(): bool
     {
-        return !empty($this->apiKey);
+        return !empty($this->apiKey) && !empty($this->applicationKey);
     }
 
     /**

--- a/database/migrations/2026_08_07_120000_add_ambient_weather_credentials.php
+++ b/database/migrations/2026_08_07_120000_add_ambient_weather_credentials.php
@@ -1,0 +1,78 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $now = now();
+
+        DB::table('settings')->insertOrIgnore([
+            'key' => 'ambient.application_key',
+            'value' => '',
+            'type' => 'encrypted',
+            'group' => 'ambient',
+            'description' => 'Ambient Weather Application Key',
+            'options' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $legacyMac = DB::table('settings')->where('key', 'ambient.device_id')->first();
+        $currentMac = DB::table('settings')->where('key', 'ambient.mac_address')->first();
+
+        if ($legacyMac && ! $currentMac) {
+            DB::table('settings')
+                ->where('key', 'ambient.device_id')
+                ->update([
+                    'key' => 'ambient.mac_address',
+                    'type' => 'string',
+                    'group' => 'ambient',
+                    'description' => 'Ambient Weather device MAC',
+                    'updated_at' => $now,
+                ]);
+        } elseif ($legacyMac) {
+            DB::table('settings')->where('key', 'ambient.device_id')->delete();
+        } elseif (! $currentMac) {
+            DB::table('settings')->insert([
+                'key' => 'ambient.mac_address',
+                'value' => '',
+                'type' => 'string',
+                'group' => 'ambient',
+                'description' => 'Ambient Weather device MAC',
+                'options' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        }
+
+        Cache::forget('setting.ambient.application_key');
+        Cache::forget('setting.ambient.device_id');
+        Cache::forget('setting.ambient.mac_address');
+    }
+
+    public function down(): void
+    {
+        $mac = DB::table('settings')->where('key', 'ambient.mac_address')->first();
+        $legacyMac = DB::table('settings')->where('key', 'ambient.device_id')->first();
+
+        if ($mac && ! $legacyMac) {
+            DB::table('settings')
+                ->where('key', 'ambient.mac_address')
+                ->update([
+                    'key' => 'ambient.device_id',
+                    'description' => 'Ambient Weather device MAC',
+                    'updated_at' => now(),
+                ]);
+        }
+
+        DB::table('settings')->where('key', 'ambient.application_key')->delete();
+
+        Cache::forget('setting.ambient.application_key');
+        Cache::forget('setting.ambient.device_id');
+        Cache::forget('setting.ambient.mac_address');
+    }
+};

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -276,7 +276,8 @@ class SettingsSeeder extends Seeder
             // ===== Ambient Weather =====
             ['key' => 'ambient.enabled', 'value' => '0', 'type' => 'boolean', 'group' => 'ambient', 'description' => 'Enable Ambient Weather API'],
             ['key' => 'ambient.api_key', 'value' => '', 'type' => 'encrypted', 'group' => 'ambient', 'description' => 'Ambient Weather API Key'],
-            ['key' => 'ambient.device_id', 'value' => '', 'type' => 'string', 'group' => 'ambient', 'description' => 'Ambient Weather device MAC'],
+            ['key' => 'ambient.application_key', 'value' => '', 'type' => 'encrypted', 'group' => 'ambient', 'description' => 'Ambient Weather Application Key'],
+            ['key' => 'ambient.mac_address', 'value' => '', 'type' => 'string', 'group' => 'ambient', 'description' => 'Ambient Weather device MAC'],
 
             // ===== Davis WeatherLink =====
             ['key' => 'weatherlink.enabled', 'value' => '0', 'type' => 'boolean', 'group' => 'weatherlink', 'description' => 'Enable Davis WeatherLink Cloud'],

--- a/resources/views/admin/settings/group.blade.php
+++ b/resources/views/admin/settings/group.blade.php
@@ -55,6 +55,16 @@
         </div>
     @endif
 
+    @if($errors->any())
+        <div class="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl">
+            <ul class="list-disc pl-5 text-sm text-red-800 dark:text-red-200 space-y-1">
+                @foreach($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
     @if($group === 'advanced')
         <div class="mb-6 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-5">
             <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">

--- a/tests/Feature/Admin/SettingsLiveDataTest.php
+++ b/tests/Feature/Admin/SettingsLiveDataTest.php
@@ -163,4 +163,52 @@ class SettingsLiveDataTest extends TestCase
         $this->assertTrue((bool) Setting::getValue('ecowitt.name_filter_enabled'));
         $this->assertSame("GW2000A\nBackyard Station", Setting::getValue('ecowitt.name_allowlist'));
     }
+
+    public function test_enabling_ambient_weather_requires_both_credentials(): void
+    {
+        Setting::setValue('ambient.enabled', false, 'boolean', 'ambient');
+        Setting::setValue('ambient.api_key', '', 'encrypted', 'ambient');
+        Setting::setValue('ambient.application_key', '', 'encrypted', 'ambient');
+
+        $admin = $this->adminUser();
+        $response = $this->actingAs($admin)
+            ->from(route('admin.settings.group', 'ambient'))
+            ->post(route('admin.settings.update', 'ambient'), [
+                '_token' => csrf_token(),
+                'ambient_enabled' => '1',
+            ]);
+
+        $response->assertRedirect(route('admin.settings.group', 'ambient'));
+        $response->assertSessionHasErrors(['ambient_api_key', 'ambient_application_key']);
+        $this->assertFalse((bool) Setting::getValue('ambient.enabled'));
+
+        $this->actingAs($admin)
+            ->get(route('admin.settings.group', 'ambient'))
+            ->assertSee('The Ambient Weather API key is required when the integration is enabled.')
+            ->assertSee('The Ambient Weather application key is required when the integration is enabled.');
+    }
+
+    public function test_saving_ambient_settings_preserves_existing_encrypted_credentials(): void
+    {
+        Setting::setValue('ambient.enabled', true, 'boolean', 'ambient');
+        Setting::setValue('ambient.api_key', 'existing-api-key', 'encrypted', 'ambient');
+        Setting::setValue('ambient.application_key', 'existing-application-key', 'encrypted', 'ambient');
+        $apiKeyCiphertext = Setting::findOrFail('ambient.api_key')->value;
+        $applicationKeyCiphertext = Setting::findOrFail('ambient.application_key')->value;
+
+        $response = $this->actingAs($this->adminUser())
+            ->post(route('admin.settings.update', 'ambient'), [
+                '_token' => csrf_token(),
+                'ambient_enabled' => '1',
+                'ambient_api_key' => '',
+                'ambient_application_key' => '',
+                'ambient_mac_address' => 'AA:BB:CC:DD:EE:FF',
+            ]);
+
+        $response->assertRedirect(route('admin.settings.group', 'ambient'));
+        $response->assertSessionHas('success');
+        $this->assertSame($apiKeyCiphertext, Setting::findOrFail('ambient.api_key')->value);
+        $this->assertSame($applicationKeyCiphertext, Setting::findOrFail('ambient.application_key')->value);
+        $this->assertSame('AA:BB:CC:DD:EE:FF', Setting::getValue('ambient.mac_address'));
+    }
 }

--- a/tests/Unit/AmbientWeatherServiceTest.php
+++ b/tests/Unit/AmbientWeatherServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Models\Setting;
+use App\Services\Weather\AmbientWeatherService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class AmbientWeatherServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+    }
+
+    public function test_service_requires_api_and_application_keys(): void
+    {
+        Setting::setValue('ambient.api_key', 'api-key', 'encrypted', 'ambient');
+
+        $this->assertFalse(app(AmbientWeatherService::class)->isConfigured());
+
+        Setting::setValue('ambient.application_key', 'application-key', 'encrypted', 'ambient');
+
+        $this->assertTrue(app(AmbientWeatherService::class)->isConfigured());
+    }
+
+    public function test_devices_request_uses_both_configured_credentials(): void
+    {
+        $this->configureCredentials();
+        Http::fake([
+            'rt.ambientweather.net/v1/devices*' => Http::response([], 200),
+        ]);
+
+        app(AmbientWeatherService::class)->getDevices();
+
+        Http::assertSent(function (Request $request): bool {
+            return $request->url() === 'https://rt.ambientweather.net/v1/devices?apiKey=api-key&applicationKey=application-key';
+        });
+    }
+
+    public function test_current_conditions_selects_configured_mac_address(): void
+    {
+        $this->configureCredentials();
+        Setting::setValue('ambient.mac_address', 'AA:BB:CC:DD:EE:02', 'string', 'ambient');
+        Http::fake([
+            'rt.ambientweather.net/v1/devices*' => Http::response([
+                $this->device('AA:BB:CC:DD:EE:01', 'First station', 50.0),
+                $this->device('AA:BB:CC:DD:EE:02', 'Selected station', 68.0),
+            ], 200),
+        ]);
+
+        $conditions = app(AmbientWeatherService::class)->getCurrentConditions();
+
+        $this->assertSame('Selected station', $conditions['device']['name']);
+        $this->assertSame('AA:BB:CC:DD:EE:02', $conditions['device']['mac_address']);
+        $this->assertSame(20.0, $conditions['outdoor']['temperature']);
+    }
+
+    private function configureCredentials(): void
+    {
+        Setting::setValue('ambient.api_key', 'api-key', 'encrypted', 'ambient');
+        Setting::setValue('ambient.application_key', 'application-key', 'encrypted', 'ambient');
+    }
+
+    private function device(string $mac, string $name, float $temperature): array
+    {
+        return [
+            'macAddress' => $mac,
+            'info' => ['name' => $name],
+            'lastData' => ['tempf' => $temperature, 'dateutc' => 1_700_000_000_000],
+        ];
+    }
+}

--- a/tests/Unit/Migrations/AddAmbientWeatherCredentialsMigrationTest.php
+++ b/tests/Unit/Migrations/AddAmbientWeatherCredentialsMigrationTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AddAmbientWeatherCredentialsMigrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_up_adds_application_key_and_renames_legacy_device_id(): void
+    {
+        DB::table('settings')->whereIn('key', [
+            'ambient.application_key',
+            'ambient.mac_address',
+            'ambient.device_id',
+        ])->delete();
+        DB::table('settings')->insert([
+            'key' => 'ambient.device_id',
+            'value' => 'AA:BB:CC:DD:EE:FF',
+            'type' => 'string',
+            'group' => 'ambient',
+            'description' => 'Ambient Weather device MAC',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->migration()->up();
+
+        $this->assertDatabaseHas('settings', [
+            'key' => 'ambient.application_key',
+            'value' => '',
+            'type' => 'encrypted',
+            'group' => 'ambient',
+        ]);
+        $this->assertDatabaseHas('settings', [
+            'key' => 'ambient.mac_address',
+            'value' => 'AA:BB:CC:DD:EE:FF',
+            'type' => 'string',
+            'group' => 'ambient',
+        ]);
+        $this->assertDatabaseMissing('settings', ['key' => 'ambient.device_id']);
+    }
+
+    public function test_up_preserves_existing_mac_address_over_legacy_value(): void
+    {
+        DB::table('settings')->whereIn('key', ['ambient.mac_address', 'ambient.device_id'])->delete();
+        DB::table('settings')->insert([
+            [
+                'key' => 'ambient.mac_address',
+                'value' => 'AA:AA:AA:AA:AA:AA',
+                'type' => 'string',
+                'group' => 'ambient',
+                'description' => 'Ambient Weather device MAC',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'key' => 'ambient.device_id',
+                'value' => 'BB:BB:BB:BB:BB:BB',
+                'type' => 'string',
+                'group' => 'ambient',
+                'description' => 'Legacy Ambient Weather device MAC',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $this->migration()->up();
+
+        $this->assertDatabaseHas('settings', [
+            'key' => 'ambient.mac_address',
+            'value' => 'AA:AA:AA:AA:AA:AA',
+        ]);
+        $this->assertDatabaseMissing('settings', ['key' => 'ambient.device_id']);
+    }
+
+    private function migration(): Migration
+    {
+        return require database_path('migrations/2026_08_07_120000_add_ambient_weather_credentials.php');
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Ambient Weather configuration so WeatherNode can authenticate with both credentials required by the API and select the configured station by MAC address.

- Add encrypted `ambient.application_key` support.
- Replace `ambient.device_id` with the consistent `ambient.mac_address` setting.
- Migrate existing installations while preserving the configured MAC value.
- Require both API and application keys when Ambient Weather is enabled.
- Preserve existing encrypted credentials when blank credential fields are submitted.
- Send both authentication parameters to Ambient Weather.
- Select the configured device by MAC address.
- Add regression coverage for settings, migration, authentication, and device selection.

## Verification

- Full suite: 321 passed, 999 assertions, 1 intentional skip.
- Production frontend build: passed.
- `git diff --check`: passed.
- Live Ambient Weather validation: passed end-to-end against a WS-2000, including ingestion and dashboard display. No credentials were added to tests or logs.

Closes #23
