### PR TITLE
Keep radar imagery out of the cache store

### DIFF
--- a/app/Http/Controllers/Api/TileProxyController.php
+++ b/app/Http/Controllers/Api/TileProxyController.php
@@ -67,29 +67,23 @@ class TileProxyController extends Controller
             return response('Invalid tile path', 400);
         }
         
-        // Generate cache key from the path
-        $cacheKey = 'radar_tile_' . md5($path);
-        
-        // Check memory cache first (fastest)
-        $tileData = Cache::get($cacheKey);
-        
-        if ($tileData) {
-            return $this->tileResponse($tileData, true);
-        }
-        
-        // Check file cache
+        // Tiles are cached on disk only, never in the cache store.
+        //
+        // This used to also Cache::put the raw PNG, on the assumption the cache
+        // was in-memory. Laravel defaults CACHE_STORE to `database`, and the
+        // cache table's value column is mediumtext/utf8mb4, so on MySQL the
+        // bytes are either rejected outright (strict mode: "Incorrect string
+        // value: '\x89PNG...'") or silently truncated to nothing (non-strict,
+        // where the read then fails to unserialize). Either way it was never a
+        // working cache, just a per-tile write into the database that could
+        // never be read back.
         $filePath = 'radar-tiles/' . $path;
-        
+
         if (Storage::disk('local')->exists($filePath)) {
-            $tileData = Storage::disk('local')->get($filePath);
-            
-            // Store in memory cache for faster subsequent access
-            Cache::put($cacheKey, $tileData, self::TILE_CACHE_TTL);
-            
-            return $this->tileResponse($tileData, true);
+            return $this->tileResponse(Storage::disk('local')->get($filePath), true);
         }
 
-        // Cache miss: fetch upstream, then cache both in DB cache and local file cache.
+        // Miss: fetch upstream and store it on disk.
         $frames = $this->resolveLatestFrames(refreshIfStale: true);
         $host = $this->resolveRainViewerHost($frames);
         $upstreamUrl = "{$host}/" . ltrim($path, '/');
@@ -102,7 +96,6 @@ class TileProxyController extends Controller
                 $tileData = $response->body();
                 if ($tileData !== '') {
                     Storage::disk('local')->put($filePath, $tileData);
-                    Cache::put($cacheKey, $tileData, self::TILE_CACHE_TTL);
                     return $this->tileResponse($tileData, false);
                 }
             }
@@ -124,7 +117,6 @@ class TileProxyController extends Controller
         // Upstream miss/error fallback: reuse the latest cached tile for the same map cell.
         $fallbackTileData = $this->findCachedFallbackTileData($path);
         if ($fallbackTileData !== null) {
-            Cache::put($cacheKey, $fallbackTileData, self::TILE_CACHE_TTL);
             return $this->tileResponse($fallbackTileData, true);
         }
 
@@ -145,10 +137,16 @@ class TileProxyController extends Controller
             return response('Unsupported upstream URL', 400);
         }
 
-        $cacheKey = 'radar_future_image_' . md5($rawUrl);
-        $cached = Cache::get($cacheKey);
-        if (is_string($cached) && $cached !== '') {
-            return $this->tileResponse($cached, true);
+        // On disk for the same reason as tiles: an image in the cache store is
+        // rejected or silently truncated on MySQL. Kept under radar-tiles/ so
+        // the existing hourly cleanup prunes these too.
+        $filePath = 'radar-tiles/future/' . md5($rawUrl) . '.img';
+
+        if (Storage::disk('local')->exists($filePath)) {
+            $age = now()->timestamp - Storage::disk('local')->lastModified($filePath);
+            if ($age < self::FUTURE_IMAGE_CACHE_TTL) {
+                return $this->tileResponse(Storage::disk('local')->get($filePath), true);
+            }
         }
 
         try {
@@ -157,7 +155,7 @@ class TileProxyController extends Controller
             if ($upstream->successful() && str_contains($contentType, 'image/')) {
                 $body = $upstream->body();
                 if ($body !== '') {
-                    Cache::put($cacheKey, $body, self::FUTURE_IMAGE_CACHE_TTL);
+                    Storage::disk('local')->put($filePath, $body);
                     return $this->tileResponse($body, false);
                 }
             }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,11 @@ x-weathernode-env: &weathernode-env
   DB_CONNECTION: "sqlite"
   DB_DATABASE: "/var/lib/weathernode/database.sqlite"
   SESSION_SECURE_COOKIE: "false"
+  # Laravel defaults CACHE_STORE to `database`. That is a reasonable default for
+  # shared hosting, but a poor one for a container that already has a persistent
+  # storage volume: every cache write becomes a row write, and on MySQL with
+  # durable commits that is an fsync per write.
+  CACHE_STORE: "file"
   CONTAINERIZED: "true"
   DOCKER_AUTO_MIGRATE: "true"
   DOCKER_AUTO_SEED: "true"
@@ -56,6 +61,13 @@ services:
     pull_policy: always
     container_name: weathernode-scheduler
     restart: unless-stopped
+    # Must match the user php-fpm runs as in the app container. Both share the
+    # storage volume, and with a file-backed cache a root-owned cache directory
+    # makes every page 500 with "Failed to open stream: No such file or
+    # directory", which reads as a missing path rather than a permissions
+    # problem. This container overrides the entrypoint, so it never runs the
+    # ownership fixups that would otherwise paper over it.
+    user: "www-data"
     environment: *weathernode-env
     depends_on:
       app:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,6 +16,25 @@ PRISTINE_MIGRATIONS="/opt/weathernode/migrations"
 
 cd "$APP_DIR"
 
+# Recursive chown is expensive on overlayfs, so only do it when something is
+# actually mis-owned. The find stops at the first offender, so the common case
+# where everything is already correct costs a traversal and no writes.
+#
+# Checks every entry rather than just the top directory: the failure this
+# guards against is a root-owned directory nested inside an already-correct
+# storage/, created by the artisan commands this script runs as root.
+fix_ownership() {
+    target="$1"
+    [ -d "$target" ] || return 0
+
+    if [ -z "$(find "$target" ! -user www-data -print -quit 2>/dev/null)" ]; then
+        return 0
+    fi
+
+    echo "[entrypoint] Fixing ownership under $target..."
+    chown -R www-data:www-data "$target" || true
+}
+
 ensure_writable_paths() {
     mkdir -p "$APP_DIR/storage/logs" "$APP_DIR/storage/app" "$APP_DIR/bootstrap/cache"
 
@@ -54,8 +73,9 @@ ensure_writable_paths() {
     # Mounted volumes can come in with restrictive host-side ownership/permissions.
     # Normalize write access at startup so Laravel can write logs/cache/sqlite.
     if [ "$(id -u)" -eq 0 ]; then
-        chown -R www-data:www-data "$APP_DIR/storage" "$APP_DIR/bootstrap/cache" || true
-        [ -d "$SQLITE_DIR" ] && chown -R www-data:www-data "$SQLITE_DIR" || true
+        fix_ownership "$APP_DIR/storage"
+        fix_ownership "$APP_DIR/bootstrap/cache"
+        [ -d "$SQLITE_DIR" ] && fix_ownership "$SQLITE_DIR"
     fi
 
     chmod 775 "$APP_DIR/storage" "$APP_DIR/bootstrap/cache" || true
@@ -113,6 +133,20 @@ if [ ! -f "$FIRST_RUN_MARKER" ]; then
     fi
 
     touch "$FIRST_RUN_MARKER"
+fi
+
+# Re-check ownership after the artisan commands above.
+#
+# Those run as root, and anything they write under storage/ is created
+# root-owned, after the fixup at the top has already run. php-fpm then serves
+# as www-data and cannot write there. With the database cache store this went
+# unnoticed, because nothing created storage/framework/cache/data in the first
+# place; on a file-backed cache every page 500s with
+# "file_put_contents(...): Failed to open stream: No such file or directory",
+# which reads as a missing path rather than a permissions problem.
+if [ "$(id -u)" -eq 0 ]; then
+    fix_ownership "$APP_DIR/storage"
+    fix_ownership "$APP_DIR/bootstrap/cache"
 fi
 
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -35,6 +35,71 @@ fix_ownership() {
     chown -R www-data:www-data "$target" || true
 }
 
+# Size the php-fpm pool to the memory the container actually has.
+#
+# The stock pool ships pm.max_children = 5. A dashboard load is one payload
+# request plus a burst of radar tiles, so five workers saturate immediately and
+# the payload queues behind the tiles.
+#
+# Raising it blindly is the wrong fix: this runs on everything from a Raspberry
+# Pi to a VPS, and pm = dynamic means the ceiling is free at idle but a burst
+# against too high a ceiling turns a slow page into an OOM kill. Slow beats
+# dead, so the ceiling is derived from the limit rather than guessed.
+#
+# Set PHP_FPM_MAX_CHILDREN to override.
+configure_php_fpm_pool() {
+    max_children="${PHP_FPM_MAX_CHILDREN:-}"
+
+    if [ -z "$max_children" ]; then
+        # cgroup v2, then v1, then the host's total as a last resort.
+        mem_bytes=""
+        if [ -r /sys/fs/cgroup/memory.max ]; then
+            mem_bytes="$(cat /sys/fs/cgroup/memory.max 2>/dev/null)"
+        elif [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+            mem_bytes="$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null)"
+        fi
+
+        # "max", or a sentinel so large it means unlimited: fall back to total RAM.
+        case "$mem_bytes" in
+            ''|max|*[!0-9]*) mem_bytes="" ;;
+        esac
+        if [ -z "$mem_bytes" ] || [ "$mem_bytes" -gt 1099511627776 ] 2>/dev/null; then
+            mem_kb="$(awk '/MemTotal/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)"
+            mem_bytes=$((mem_kb * 1024))
+        fi
+
+        mem_mb=$((mem_bytes / 1048576))
+
+        # Measured ~55 MB resident per worker serving the dashboard; 64 leaves
+        # headroom. Only 60% of memory is handed to php-fpm, since nginx, the
+        # scheduler and possibly a database live here too.
+        if [ "$mem_mb" -gt 0 ]; then
+            max_children=$(( (mem_mb * 60 / 100) / 64 ))
+        else
+            max_children=5
+        fi
+
+        [ "$max_children" -lt 5 ] && max_children=5
+        [ "$max_children" -gt 32 ] && max_children=32
+    fi
+
+    start_servers=$(( max_children / 4 ))
+    [ "$start_servers" -lt 2 ] && start_servers=2
+    max_spare=$(( max_children / 2 ))
+    [ "$max_spare" -lt "$start_servers" ] && max_spare="$start_servers"
+
+    cat > /usr/local/etc/php-fpm.d/zz-weathernode.conf <<CONF
+[www]
+pm = dynamic
+pm.max_children = ${max_children}
+pm.start_servers = ${start_servers}
+pm.min_spare_servers = 2
+pm.max_spare_servers = ${max_spare}
+CONF
+
+    echo "[entrypoint] php-fpm pool: max_children=${max_children} (container memory: ${mem_mb:-unknown} MB)"
+}
+
 ensure_writable_paths() {
     mkdir -p "$APP_DIR/storage/logs" "$APP_DIR/storage/app" "$APP_DIR/bootstrap/cache"
 
@@ -87,6 +152,7 @@ ensure_writable_paths() {
 }
 
 ensure_writable_paths
+configure_php_fpm_pool
 
 case "${APP_KEY:-}" in
     ""|"base64:REPLACE_WITH_YOUR_GENERATED_KEY"|"REPLACE_WITH_YOUR_APP_KEY")

--- a/tests/Feature/Api/TileProxyStorageTest.php
+++ b/tests/Feature/Api/TileProxyStorageTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Http\Middleware\ApiKeyMiddleware;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * Radar imagery must never go through the cache store.
+ *
+ * The cache table's value column is mediumtext/utf8mb4, so PNG bytes are
+ * rejected on MySQL in strict mode and silently truncated without it. Tiles
+ * are kept on the local disk instead, which is where blobs belong.
+ */
+class TileProxyStorageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TILE_PATH = 'v2/radar/1737561600/256/5/16/10/1/1_0.png';
+
+    /** A real 1x1 PNG: starts \x89PNG, which is not valid UTF-8. */
+    private function pngBytes(): string
+    {
+        return base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+        );
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('local');
+        $this->withoutMiddleware(ApiKeyMiddleware::class);
+
+        // phpunit.xml runs on the array store, where anything at all can be
+        // cached and these assertions would pass no matter what the controller
+        // does. The bug only exists on a real backing store, so use the one
+        // Laravel actually defaults to.
+        config(['cache.default' => 'database']);
+        Cache::store('database')->clear();
+    }
+
+    /**
+     * Cache keys the controller used to write image bytes under.
+     *
+     * Asserted by key rather than by inspecting stored bytes: whether a binary
+     * value survives a text column is engine-specific (SQLite keeps it, MySQL
+     * rejects or truncates it), so checking the value would make this test pass
+     * or fail for reasons unrelated to the controller.
+     */
+    private function imageCacheKeys(): array
+    {
+        return DB::table('cache')
+            ->where(function ($q) {
+                $q->where('key', 'like', '%radar_tile_%')
+                    ->orWhere('key', 'like', '%radar_future_image_%');
+            })
+            ->pluck('key')
+            ->all();
+    }
+
+    public function test_a_png_is_not_valid_utf8(): void
+    {
+        // The premise the rest of this class rests on.
+        $this->assertFalse(mb_check_encoding($this->pngBytes(), 'UTF-8'));
+    }
+
+    public function test_fetching_a_tile_writes_no_binary_into_the_cache_store(): void
+    {
+        $png = $this->pngBytes();
+        Http::fake(['*' => Http::response($png, 200, ['Content-Type' => 'image/png'])]);
+
+        $response = $this->get('/api/radar/tile/' . self::TILE_PATH);
+
+        $response->assertOk();
+        $this->assertSame($png, $response->getContent());
+
+        $this->assertSame([], $this->imageCacheKeys(), 'tile bytes were written into the cache store');
+    }
+
+    public function test_the_tile_is_stored_on_disk(): void
+    {
+        Http::fake(['*' => Http::response($this->pngBytes(), 200, ['Content-Type' => 'image/png'])]);
+
+        $this->get('/api/radar/tile/' . self::TILE_PATH)->assertOk();
+
+        Storage::disk('local')->assertExists('radar-tiles/' . self::TILE_PATH);
+        $this->assertSame($this->pngBytes(), Storage::disk('local')->get('radar-tiles/' . self::TILE_PATH));
+    }
+
+    public function test_a_second_request_is_served_from_disk_without_refetching(): void
+    {
+        $png = $this->pngBytes();
+        Http::fake(['*' => Http::response($png, 200, ['Content-Type' => 'image/png'])]);
+
+        $this->get('/api/radar/tile/' . self::TILE_PATH)->assertOk();
+        $upstreamCallsAfterFirst = count(Http::recorded());
+
+        $second = $this->get('/api/radar/tile/' . self::TILE_PATH);
+
+        $second->assertOk();
+        $this->assertSame($png, $second->getContent());
+        $this->assertCount($upstreamCallsAfterFirst, Http::recorded(), 'the disk copy should have served this');
+    }
+
+    /**
+     * The path that used to throw: it sits outside the controller's try/catch,
+     * so on strict MySQL it surfaced as a 500 for every tile once the file
+     * existed.
+     */
+    public function test_a_disk_hit_does_not_touch_the_cache_store(): void
+    {
+        Storage::disk('local')->put('radar-tiles/' . self::TILE_PATH, $this->pngBytes());
+        Http::preventStrayRequests();
+
+        $response = $this->get('/api/radar/tile/' . self::TILE_PATH);
+
+        $response->assertOk();
+        $this->assertSame([], $this->imageCacheKeys(), 'serving from disk must not write tile bytes to the cache');
+    }
+
+    public function test_future_images_are_stored_on_disk_too(): void
+    {
+        $png = $this->pngBytes();
+        Http::fake(['*' => Http::response($png, 200, ['Content-Type' => 'image/png'])]);
+
+        $url = 'https://digital.weather.gov/some/frame.png';
+        $response = $this->get('/api/radar/future-image?url=' . urlencode($url));
+
+        $response->assertOk();
+        $this->assertSame([], $this->imageCacheKeys(), 'future image bytes were written into the cache store');
+        Storage::disk('local')->assertExists('radar-tiles/future/' . md5($url) . '.img');
+    }
+
+    public function test_future_images_are_served_from_disk_on_a_repeat_request(): void
+    {
+        $png = $this->pngBytes();
+        Http::fake(['*' => Http::response($png, 200, ['Content-Type' => 'image/png'])]);
+        $url = 'https://digital.weather.gov/some/frame.png';
+
+        $this->get('/api/radar/future-image?url=' . urlencode($url))->assertOk();
+        $callsAfterFirst = count(Http::recorded());
+
+        $second = $this->get('/api/radar/future-image?url=' . urlencode($url));
+
+        $second->assertOk();
+        $this->assertCount($callsAfterFirst, Http::recorded(), 'the disk copy should have served this');
+    }
+}


### PR DESCRIPTION
Fixes #37. The report is accurate, and the root cause turned out to be worse than slowness.

## It is not a performance problem, it is a broken cache

`TileProxyController` wrote each tile to the local disk and then also `Cache::put` the raw PNG, with comments calling the cache "memory". Laravel defaults `CACHE_STORE` to `database`, and the cache table's `value` column is `mediumtext` / `utf8mb4`. PNG bytes are not valid UTF-8.

Verified against real MySQL 8 in strict mode, which is the default:

| | unfixed | fixed |
|---|---|---|
| 1st request | HTTP 200, **68 bytes** (transparent pixel, not the tile) | HTTP 200, 70 bytes |
| 2nd request | **uncaught QueryException → HTTP 500** | HTTP 200, 70 bytes, byte identical |
| `radar_tile` rows in cache table | present | 0 |

The first request loses the tile because `Cache::put` throws inside the controller's `try`, and the catch logs it as `"Radar tile upstream fetch exception"` — the fetch succeeded, so the log is actively misleading. Every request after that hits the disk-hit branch, which sits *outside* that try, so it surfaces as a 500.

Without strict mode there is no error at all: the value is truncated at the first invalid byte and the read fails to unserialize. **70 bytes in, 0 bytes out.** That is the reported install: a per-tile database write that can never be read back, which explains both the write amplification and a cache table that is 98.8% dead rows.

## The fix

Drop the cache layer for tiles. The disk copy on the line above already serves this purpose and is faster than the store it was fronting on every driver except Redis. Future radar images move to disk too, under `radar-tiles/future/` so the existing hourly cleanup prunes them. Frames metadata stays cached, since that is JSON and belongs there.

## Second half: the Docker default, and the trap under it

Switching the shipped compose to `CACHE_STORE=file` **breaks every page on its own**, which is worth spelling out.

The entrypoint normalises ownership under `storage/`, then runs `migrate`, `storage:link` and `db:seed` as root. Anything those write is created root-owned, *after* the fixup ran. php-fpm serves as www-data and cannot write there. With the database store nothing ever created `storage/framework/cache/data`, so nobody noticed. On a file cache:

```
file_put_contents(.../storage/framework/cache/data/f2/7d/...):
Failed to open stream: No such file or directory
```

Confirmed on the published v2026.08.3 image: `CACHE_STORE=file` → HTTP 500, default → HTTP 200, and `cache/data` is `root:root 755` inside a `www-data` storage tree. This is the same class of problem as the reporter's scheduler note, from a different direction.

So the ownership check now runs again after the bootstrap commands, and inspects every entry rather than just the top directory, since the offender is nested inside an already-correct `storage/`. The `find` stops at the first mismatch, so the normal case costs a traversal and no writes — which also avoids a pointless overlayfs copy-up on every recreate.

The scheduler gets `user: "www-data"` as suggested, since it shares the storage volume and overrides the entrypoint so it never runs these fixups.

## Testing

7 new tests in `tests/Feature/Api/TileProxyStorageTest.php`, mutation-checked: 3 of them fail against the unfixed controller.

Two things I corrected while writing them, worth mentioning because the first version looked fine and proved nothing:

- `phpunit.xml` runs on the `array` cache store, where any value can be cached, so the assertions passed no matter what the controller did. They now force the `database` store.
- Asserting on stored *bytes* is engine-specific: SQLite keeps binary in a text column happily, MySQL does not. The tests assert on cache *keys* instead, so they mean the same thing on either engine.

I also removed one test that passed in both the fixed and unfixed states. It looked like coverage and was not.

Container verification: patched image with `CACHE_STORE=file` serves HTTP 200, the log shows the post-bootstrap fixup catching `cache/data`, zero mis-owned files remain under `storage`, radar tiles round-trip byte identical, and a scheduler running as www-data can write to the shared cache.

325 tests pass.

## Note

Touches the same entrypoint function as #38. Whichever lands second needs a small manual merge.

Also from the report, not done here: `pm.max_children = 5` in the image is low for a dashboard that fires a payload request plus a burst of tiles. Independent of this, and worth its own change.