### PR TITLE
Document the API and integration examples

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,7 +7,11 @@ paths = [
   '''database/seeders/SettingsSeeder\.php''',
   '''resources/js/pages/dashboard\.js''',
   '''resources/lang/ca-es\.json''',
-  '''resources/lang/de-de\.json'''
+  '''resources/lang/de-de\.json''',
+  # API documentation: curl examples carry an "X-API-Key: YOUR_API_KEY"
+  # placeholder header, which trips the curl-auth-header rule.
+  '''docs/API\.md''',
+  '''resources/views/admin/api-keys/index\.blade\.php'''
 ]
 regexes = [
   '''meteouitgeest_ads_consent_v1''',

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Detailed admin operations live in [ADMIN_GUIDE.md](ADMIN_GUIDE.md).
 🔐 API and security
 
 - JSON API is protected by API keys. You manage keys at /admin/api-keys.
+- Authentication, endpoints, response details, and integration examples are documented in [docs/API.md](docs/API.md).
 - Optional secure push mode for Ecowitt receivers.
 
 📡 Community telemetry

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,457 @@
+# WeatherNode API
+
+WeatherNode exposes weather observations, forecasts, radar data, air quality data, and selected station services through a JSON API. This guide covers authentication, rate limits, endpoints, and a few practical integration examples.
+
+The examples use `https://weather.example.com` as the WeatherNode address. Replace it with the address of your own installation.
+
+## Quick start
+
+Create an API key in **Admin > API Keys**, then send it in the `X-API-Key` header:
+
+```bash
+curl --fail --silent --show-error \
+  -H "Accept: application/json" \
+  -H "X-API-Key: YOUR_API_KEY" \
+  "https://weather.example.com/api/weather/current"
+```
+
+Most responses use this general shape:
+
+```json
+{
+  "success": true,
+  "data": {
+    "temperature": 18.4,
+    "humidity": 72,
+    "wind_speed": 9.7
+  }
+}
+```
+
+Fields can be `null` when a sensor or data source is not available. Some disabled or unavailable services return HTTP 200 with `success: false`, so clients should check the `success` field as well as the HTTP status.
+
+## Authentication
+
+WeatherNode has two kinds of API keys:
+
+- **Public keys** can read the weather, radar, and public air quality endpoints. They are suitable for browser dashboards and trusted home automation systems.
+- **Private keys** can use every endpoint, including external provider data, telemetry, and forecast narration. Keep private keys on a server or another trusted device.
+
+All normal API requests must send the key in the `X-API-Key` header.
+
+```http
+X-API-Key: YOUR_API_KEY
+```
+
+The `api_key` query parameter is accepted only for these image endpoints, where browsers may not be able to add a request header:
+
+- `/api/radar/tile/*`
+- `/api/radar/future-image`
+
+Do not put a private key in a URL. URLs are commonly stored in browser history, access logs, and monitoring tools.
+
+`POST /api/ecowitt/receive/{token?}` is the only endpoint that does not use a WeatherNode API key. It has its own receiver security settings.
+
+## Rate limits
+
+The default limit is 120 requests per minute for each API key and client IP combination. An administrator can set a different limit when creating a key.
+
+Radar tile and future image requests use a separate allowance of five times the key limit. A key with the default limit can therefore make up to 600 radar image requests per minute from one client IP.
+
+When a limit is exceeded, WeatherNode returns HTTP 429 and a `Retry-After` header:
+
+```json
+{
+  "error": "Rate limit exceeded"
+}
+```
+
+## Language and units
+
+Use `lang` or `locale` to select the language used for translated or generated text:
+
+```text
+/api/weather/forecast?lang=nl-nl
+```
+
+Weather readings are returned in canonical metric units. In most endpoints these are:
+
+- Temperature: degrees Celsius
+- Wind speed: kilometres per hour
+- Pressure: hectopascals
+- Rain: millimetres
+- Distance: kilometres
+
+The `units` preference used by the web interface does not convert API values. Integrations should convert values themselves when another unit system is needed.
+
+## Errors
+
+Authentication and rate limit errors use a small error object:
+
+| Status | Meaning | Response |
+| --- | --- | --- |
+| 401 | No key was supplied | `{"error":"API key required"}` |
+| 401 | The key is invalid or revoked | `{"error":"Invalid API key"}` |
+| 403 | A public key was used for a private endpoint | `{"error":"Private API key required"}` |
+| 429 | The key exceeded its request limit | `{"error":"Rate limit exceeded"}` |
+
+Endpoint validation errors usually return `success: false` with a message. Laravel validation responses, such as those from forecast narration, return HTTP 422 with `message` and `errors`.
+
+## Endpoint reference
+
+Access values used below:
+
+- **Public** means a valid public or private API key can be used.
+- **Private** means a private API key is required.
+- **Receiver** means the endpoint uses Ecowitt receiver security instead of a WeatherNode API key.
+
+### Weather
+
+| Method | Endpoint | Access | Description |
+| --- | --- | --- | --- |
+| GET | `/api/weather/dashboard` | Public | Combined payload used by the main dashboard |
+| GET | `/api/weather/current` | Public | Latest station reading and station details |
+| GET | `/api/weather/today` | Public | Daily minimum, maximum, average, rain, and wind summary |
+| GET | `/api/weather/forecast` | Public | Daily and hourly forecast data |
+| GET | `/api/weather/air-quality` | Public | WAQI data and local particulate readings |
+| GET | `/api/weather/noise` | Public | Sensor.Community noise data when configured |
+| GET | `/api/weather/astronomy` | Public | Sun, moon, meteor, aurora, and space data |
+| GET | `/api/weather/metar` | Public | Aviation weather for the configured or requested ICAO station |
+| GET | `/api/weather/history` | Public | Sampled historical values for one field |
+| GET | `/api/weather/sensors` | Public | Available sensor groups and battery state |
+| GET | `/api/weather/radar` | Public | RainViewer radar frame metadata |
+| GET | `/api/weather/radar-nowcast` | Public | Configured short-term radar nowcast |
+| GET | `/api/weather/radar-future-frames` | Public | Future radar frame metadata |
+| GET | `/api/weather/solar-nowcast` | Public | Configured solar radiation nowcast |
+| GET | `/api/weather/wms-layers` | Public | Available KNMI WMS layers and timestamps |
+| GET | `/api/weather/wms-map` | Public | URL and legend for a KNMI WMS layer |
+
+#### Current conditions
+
+`GET /api/weather/current`
+
+The `data` object contains the latest recorded values. Common fields include:
+
+- `recorded_at`
+- `temperature`, `feels_like`, `dew_point`, `heat_index`, `wind_chill`
+- `humidity`, `pressure_rel`, `pressure_abs`
+- `wind_speed`, `wind_gust`, `wind_direction`
+- `rain_rate`, `rain_hourly`, `rain_daily`
+- `uv_index`, `solar_radiation`
+- Extra temperature, soil, particulate, CO2, leak, and lightning fields when those sensors are present
+
+The `station` object contains the configured station name, location, latitude, and longitude.
+
+#### Forecast
+
+`GET /api/weather/forecast`
+
+Optional query parameters:
+
+| Parameter | Description |
+| --- | --- |
+| `lang` or `locale` | Language for generated forecast text, for example `nl-nl` or `en-gb` |
+
+The response contains `data.daily`, `data.hourly`, and `meta`. Daily forecasts can include temperature, precipitation, wind, symbols, and generated narrative text. Hourly entries depend on the configured forecast provider.
+
+#### Weather history
+
+`GET /api/weather/history`
+
+Query parameters:
+
+| Parameter | Default | Accepted values |
+| --- | --- | --- |
+| `period` | `24h` | `24h`, `48h`, `7d`, `30d`, `1y` |
+| `field` | `temperature` | A supported weather or sensor field |
+
+Common fields include `temperature`, `humidity`, `pressure_rel`, `wind_speed`, `wind_gust`, `wind_direction`, `rain_rate`, `rain_daily`, `uv_index`, `solar_radiation`, `pm25_ch1`, `pm10`, `co2`, `lightning_count`, and `lightning_distance`.
+
+```bash
+curl --fail --silent --show-error \
+  -H "X-API-Key: YOUR_API_KEY" \
+  "https://weather.example.com/api/weather/history?period=24h&field=temperature"
+```
+
+Example response:
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "time": "2026-08-09T12:00:00+00:00",
+      "value": 18.4
+    }
+  ],
+  "field": "temperature",
+  "period": "24h",
+  "sampling": {
+    "bucket_seconds": 300,
+    "max_points": 300
+  }
+}
+```
+
+#### METAR
+
+`GET /api/weather/metar`
+
+The optional `icao` parameter selects a four-letter ICAO station:
+
+```text
+/api/weather/metar?icao=EHAM
+```
+
+An invalid ICAO code returns HTTP 422. When METAR support is disabled, the endpoint returns a successful response with `data: null`.
+
+#### KNMI WMS
+
+`GET /api/weather/wms-map`
+
+Query parameters:
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `layer` | None | Layer key returned by `/api/weather/wms-layers` |
+| `style` | `default` | WMS legend style |
+| `time` | `latest` | Requested WMS time |
+| `width` | `512` | Map width in pixels |
+| `height` | `512` | Map height in pixels |
+| `opacity` | `1` | Requested opacity |
+
+At present, `time` and `opacity` are accepted for compatibility but are not applied to the generated map URL. The `style` value is used for the legend URL. Use `/api/weather/wms-layers` to discover valid layer keys and available provider times.
+
+### Public data and radar
+
+| Method | Endpoint | Access | Description |
+| --- | --- | --- | --- |
+| GET | `/api/ecowitt/status` | Public | Receiver status, station details, and battery state |
+| GET | `/api/data/luftdaten` | Public | Sensor.Community air quality data |
+| GET | `/api/radar/frames` | Public | Cached RainViewer frame metadata |
+| GET | `/api/radar/tile/{path}` | Public | Cached PNG radar tile |
+| GET | `/api/radar/future-image` | Public | Cached PNG from an allowed future radar provider |
+
+Radar tile paths use the RainViewer format:
+
+```text
+/api/radar/tile/v2/radar/{timestamp}/{size}/{z}/{x}/{y}/{color}/{options}.png
+```
+
+`GET /api/radar/future-image` requires a URL-encoded HTTPS `url` parameter. Only providers allowed by the WeatherNode server are accepted.
+
+These two image endpoints return `image/png`, not JSON. On an upstream error they can return a transparent placeholder image so maps do not break.
+
+### Private data
+
+| Method | Endpoint | Access | Description |
+| --- | --- | --- | --- |
+| GET | `/api/data/alerts` | Private | Weather alerts and highest severity |
+| GET | `/api/data/earthquakes` | Private | Recent earthquakes and statistics |
+| GET | `/api/data/purpleair` | Private | PurpleAir data when configured |
+| GET | `/api/data/air-quality` | Private | Combined air quality sources |
+| GET | `/api/data/lightning` | Private | Configured lightning source |
+| GET | `/api/data/external` | Private | Combined external data cache |
+| GET | `/api/sources/aeris` | Private | AerisWeather source data |
+| GET | `/api/sources/weatherlink` | Private | WeatherLink source data |
+| GET | `/api/sources/ambient` | Private | Ambient Weather source data |
+| GET | `/api/sources/weatherflow` | Private | WeatherFlow source data |
+| GET | `/api/telemetry/stations` | Private | Community station telemetry |
+| POST | `/api/forecast/narrate` | Private | Generate readable text from structured forecast data |
+
+Private source endpoints may include data obtained with third-party credentials. Only give private keys to integrations you trust.
+
+#### Forecast narration
+
+`POST /api/forecast/narrate`
+
+Send JSON containing any available forecast fields:
+
+```bash
+curl --fail --silent --show-error \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: YOUR_PRIVATE_API_KEY" \
+  --data '{
+    "date": "2026-08-10",
+    "min_temp_c": 13,
+    "max_temp_c": 22,
+    "wind_ms": 4.2,
+    "wind_dir_deg": 240,
+    "precip_prob_pct": 35,
+    "precip_mm": 1.4,
+    "cloud_pct": 60
+  }' \
+  "https://weather.example.com/api/forecast/narrate"
+```
+
+The response contains the supplied date and generated text:
+
+```json
+{
+  "date": "2026-08-10",
+  "text": "..."
+}
+```
+
+### Ecowitt receiver
+
+| Method | Endpoint | Access | Description |
+| --- | --- | --- | --- |
+| POST | `/api/ecowitt/receive/{token?}` | Receiver | Receive a push from an Ecowitt station |
+
+Configure the endpoint in WS View or the Ecowitt app under the customized weather service settings.
+
+```text
+https://weather.example.com/api/ecowitt/receive
+```
+
+When secure receiver mode is enabled, use the configured path token:
+
+```text
+https://weather.example.com/api/ecowitt/receive/YOUR_RECEIVER_TOKEN
+```
+
+Ecowitt sends form data containing fields such as `tempf`, `humidity`, `baromrelin`, `windspeedmph`, `winddir`, `rainratein`, and `solarradiation`. WeatherNode converts incoming imperial values to canonical metric values before storage.
+
+The receiver returns plain text:
+
+| Status | Response | Meaning |
+| --- | --- | --- |
+| 200 | `OK` | Reading accepted |
+| 400 | `Invalid data` | The payload did not contain a usable reading |
+| 403 | Plain-text reason | Token, passkey, source IP, or station filter rejected the push |
+| 503 | Plain-text reason | Secure receiver settings are incomplete |
+
+## Integration examples
+
+The following examples are starting points. Field availability depends on the sensors and services enabled on your WeatherNode installation.
+
+### Home Assistant
+
+Home Assistant can read the current endpoint with its built-in [RESTful Sensor](https://www.home-assistant.io/integrations/sensor.rest/) integration.
+
+Add this to `configuration.yaml`:
+
+```yaml
+rest:
+  - resource: https://weather.example.com/api/weather/current
+    headers:
+      X-API-Key: !secret weathernode_api_key
+      Accept: application/json
+    scan_interval: 60
+    sensor:
+      - name: WeatherNode temperature
+        unique_id: weathernode_temperature
+        value_template: "{{ value_json.data.temperature }}"
+        unit_of_measurement: "°C"
+        device_class: temperature
+        state_class: measurement
+      - name: WeatherNode humidity
+        unique_id: weathernode_humidity
+        value_template: "{{ value_json.data.humidity }}"
+        unit_of_measurement: "%"
+        device_class: humidity
+        state_class: measurement
+      - name: WeatherNode wind speed
+        unique_id: weathernode_wind_speed
+        value_template: "{{ value_json.data.wind_speed }}"
+        unit_of_measurement: "km/h"
+        device_class: wind_speed
+        state_class: measurement
+```
+
+Store the key in `secrets.yaml`:
+
+```yaml
+weathernode_api_key: YOUR_API_KEY
+```
+
+Restart Home Assistant after checking the configuration. A public key is sufficient for this integration.
+
+### Node-RED
+
+Use an **inject** node, a **function** node, and an **http request** node.
+
+Put this in the function node:
+
+```javascript
+msg.method = "GET";
+msg.url = "https://weather.example.com/api/weather/current";
+msg.headers = {
+    Accept: "application/json",
+    "X-API-Key": env.get("WEATHERNODE_API_KEY"),
+};
+
+return msg;
+```
+
+Set the HTTP request node to return a parsed JSON object. Keeping the key in a Node-RED environment variable avoids storing it directly in an exported flow.
+
+### Telegraf
+
+Telegraf can poll WeatherNode and write selected numeric fields to InfluxDB or another supported output.
+
+```toml
+[[inputs.http]]
+  urls = ["https://weather.example.com/api/weather/current"]
+  method = "GET"
+  interval = "60s"
+  timeout = "10s"
+  data_format = "json_v2"
+
+  [inputs.http.headers]
+    Accept = "application/json"
+    X-API-Key = "${WEATHERNODE_API_KEY}"
+
+  [[inputs.http.json_v2.object]]
+    path = "data"
+    included_keys = [
+      "temperature",
+      "humidity",
+      "pressure_rel",
+      "wind_speed",
+      "wind_gust",
+      "rain_rate",
+      "solar_radiation"
+    ]
+```
+
+Set `WEATHERNODE_API_KEY` in the Telegraf service environment before starting it.
+
+### Python
+
+```python
+import os
+
+import requests
+
+base_url = "https://weather.example.com"
+api_key = os.environ["WEATHERNODE_API_KEY"]
+
+response = requests.get(
+    f"{base_url}/api/weather/current",
+    headers={
+        "Accept": "application/json",
+        "X-API-Key": api_key,
+    },
+    timeout=10,
+)
+response.raise_for_status()
+
+payload = response.json()
+if not payload.get("success"):
+    raise RuntimeError(payload.get("message", "WeatherNode returned no data"))
+
+print(payload["data"]["temperature"])
+```
+
+## Operational notes
+
+- API keys are shown in full only when they are created. Store them in a password manager or secret store.
+- Revoke a key from **Admin > API Keys** when an integration no longer needs access.
+- Use a separate key for each integration. This makes revocation and rate limit changes safer.
+- Poll current conditions no more often than the station updates. Once per minute is a sensible starting point for most installations.
+- The dashboard payload is cached briefly and is useful when one client needs many widgets at once.
+- Endpoint fields may grow as WeatherNode adds sensors and providers. Clients should ignore fields they do not recognise.
+- WeatherNode does not currently publish a versioned API path. Check release notes before relying on newly added fields.

--- a/resources/views/admin/api-keys/index.blade.php
+++ b/resources/views/admin/api-keys/index.blade.php
@@ -157,6 +157,232 @@
     </div>
 @endif
 
+<section class="mt-8 space-y-5" aria-labelledby="api-guide-title">
+    <div class="overflow-hidden rounded-xl border border-sky-200 bg-white shadow-sm dark:border-sky-900/70 dark:bg-gray-800">
+        <div class="border-b border-sky-100 bg-gradient-to-r from-sky-50 to-blue-50 px-5 py-5 dark:border-sky-900/70 dark:from-sky-950/40 dark:to-blue-950/30">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div class="max-w-3xl">
+                    <div class="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-sky-700 dark:text-sky-300">
+                        <span class="inline-block h-2 w-2 rounded-full bg-sky-500"></span>
+                        {{ __('Developer guide') }}
+                    </div>
+                    <h2 id="api-guide-title" class="text-xl font-bold text-gray-900 dark:text-white">{{ __('Using the WeatherNode API') }}</h2>
+                    <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">
+                        {{ __('Read station data from scripts, dashboards, and home automation tools. Replace weather.example.com with the address of your own installation. Start with a public key. Use a private key only for trusted server-side integrations that need protected data sources.') }}
+                    </p>
+                </div>
+                <a href="https://github.com/{{ config('updater.github_repo') }}/blob/main/docs/API.md"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-sky-300 bg-white px-4 py-2 text-sm font-medium text-sky-700 transition hover:border-sky-400 hover:bg-sky-50 dark:border-sky-700 dark:bg-gray-800 dark:text-sky-300 dark:hover:bg-sky-950/40">
+                    {{ __('Open full API reference') }}
+                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h4m0 0v4m0-4L10 14M7 7H5a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-2"/>
+                    </svg>
+                </a>
+            </div>
+        </div>
+
+        <div class="grid gap-px bg-gray-100 dark:bg-gray-700/60 md:grid-cols-3">
+            <div class="bg-white p-5 dark:bg-gray-800">
+                <div class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('Base URL') }}</div>
+                <code class="mt-2 block break-all text-sm font-medium text-gray-900 dark:text-gray-100">https://weather.example.com/api</code>
+            </div>
+            <div class="bg-white p-5 dark:bg-gray-800">
+                <div class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('Authentication') }}</div>
+                <code class="mt-2 block text-sm font-medium text-gray-900 dark:text-gray-100">X-API-Key: YOUR_API_KEY</code>
+            </div>
+            <div class="bg-white p-5 dark:bg-gray-800">
+                <div class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('Default limit') }}</div>
+                <div class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">120 {{ __('requests per minute') }}</div>
+            </div>
+        </div>
+    </div>
+
+    <div class="grid gap-5 xl:grid-cols-5">
+        <div class="rounded-xl border border-gray-100 bg-white p-5 shadow-sm dark:border-gray-700/50 dark:bg-gray-800 xl:col-span-3">
+            <div class="flex items-start justify-between gap-4">
+                <div>
+                    <h3 class="text-base font-semibold text-gray-900 dark:text-white">{{ __('Quick test') }}</h3>
+                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ __('Replace the placeholder with one of your keys, then run this command in a terminal.') }}</p>
+                </div>
+                <button type="button"
+                        onclick="copyCode('api-curl-example', this)"
+                        class="shrink-0 rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-700 transition hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">
+                    {{ __('Copy') }}
+                </button>
+            </div>
+            <pre id="api-curl-example" class="mt-4 overflow-x-auto rounded-lg bg-slate-950 p-4 text-xs leading-6 text-slate-100"><code>curl --fail --silent --show-error \
+  -H "Accept: application/json" \
+  -H "X-API-Key: YOUR_API_KEY" \
+  "https://weather.example.com/api/weather/current"</code></pre>
+            <p class="mt-3 text-xs leading-5 text-gray-500 dark:text-gray-400">
+                {{ __('A successful response contains the latest reading in the data object. Sensor fields can be null when that sensor is not available.') }}
+            </p>
+        </div>
+
+        <aside class="rounded-xl border border-amber-200 bg-amber-50 p-5 dark:border-amber-900/60 dark:bg-amber-950/20 xl:col-span-2">
+            <h3 class="flex items-center gap-2 text-sm font-semibold text-amber-900 dark:text-amber-200">
+                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 11c0-1.105.895-2 2-2s2 .895 2 2v2m-4-2V7a4 4 0 118 0v4m-9 10h10a2 2 0 002-2v-6a2 2 0 00-2-2H11a2 2 0 00-2 2v6a2 2 0 002 2z"/>
+                </svg>
+                {{ __('Choose the right key') }}
+            </h3>
+            <div class="mt-3 space-y-3 text-sm leading-6 text-amber-900/90 dark:text-amber-100/80">
+                <p><strong>{{ __('Public key:') }}</strong> {{ __('Use for weather, radar, and public air quality endpoints. This is enough for Home Assistant and most dashboards.') }}</p>
+                <p><strong>{{ __('Private key:') }}</strong> {{ __('Use only on trusted systems that need protected provider, telemetry, or forecast narration endpoints.') }}</p>
+                <p class="text-xs">{{ __('Create a separate key for each integration so it can be revoked without affecting anything else.') }}</p>
+            </div>
+        </aside>
+    </div>
+
+    <div class="overflow-hidden rounded-xl border border-gray-100 bg-white shadow-sm dark:border-gray-700/50 dark:bg-gray-800">
+        <details open class="group border-b border-gray-100 dark:border-gray-700/60">
+            <summary class="flex cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 text-sm font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-gray-700/30">
+                <span>{{ __('Public endpoint overview') }}</span>
+                <svg class="h-5 w-5 text-gray-400 transition group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                </svg>
+            </summary>
+            <div class="border-t border-gray-100 px-5 py-5 dark:border-gray-700/60">
+                <div class="overflow-x-auto">
+                    <table class="min-w-full text-left text-sm">
+                        <thead class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                            <tr>
+                                <th class="pb-3 pr-6 font-semibold">{{ __('Endpoint') }}</th>
+                                <th class="pb-3 font-semibold">{{ __('Returns') }}</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-100 dark:divide-gray-700/60">
+                            <tr><td class="py-3 pr-6"><code>/api/weather/current</code></td><td class="py-3 text-gray-600 dark:text-gray-300">{{ __('Latest station reading') }}</td></tr>
+                            <tr><td class="py-3 pr-6"><code>/api/weather/today</code></td><td class="py-3 text-gray-600 dark:text-gray-300">{{ __('Daily minimum, maximum, rain, and wind summary') }}</td></tr>
+                            <tr><td class="py-3 pr-6"><code>/api/weather/forecast</code></td><td class="py-3 text-gray-600 dark:text-gray-300">{{ __('Daily and hourly forecast') }}</td></tr>
+                            <tr><td class="py-3 pr-6"><code>/api/weather/history</code></td><td class="py-3 text-gray-600 dark:text-gray-300">{{ __('Sampled historical values for charts and automations') }}</td></tr>
+                            <tr><td class="py-3 pr-6"><code>/api/weather/air-quality</code></td><td class="py-3 text-gray-600 dark:text-gray-300">{{ __('Configured air quality readings') }}</td></tr>
+                            <tr><td class="py-3 pr-6"><code>/api/weather/astronomy</code></td><td class="py-3 text-gray-600 dark:text-gray-300">{{ __('Sun, moon, meteor, aurora, and space data') }}</td></tr>
+                            <tr><td class="py-3 pr-6"><code>/api/weather/dashboard</code></td><td class="py-3 text-gray-600 dark:text-gray-300">{{ __('Combined payload used by the public dashboard') }}</td></tr>
+                            <tr><td class="py-3 pr-6"><code>/api/radar/frames</code></td><td class="py-3 text-gray-600 dark:text-gray-300">{{ __('Radar frame metadata') }}</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+                <p class="mt-4 text-xs text-gray-500 dark:text-gray-400">
+                    {{ __('The full reference includes all weather, WMS, radar, receiver, data source, telemetry, and narration endpoints.') }}
+                </p>
+            </div>
+        </details>
+
+        <details class="group border-b border-gray-100 dark:border-gray-700/60">
+            <summary class="flex cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 text-sm font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-gray-700/30">
+                <span>{{ __('Home Assistant example') }}</span>
+                <svg class="h-5 w-5 text-gray-400 transition group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                </svg>
+            </summary>
+            <div class="border-t border-gray-100 px-5 py-5 dark:border-gray-700/60">
+                <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">
+                    {{ __('Home Assistant can read WeatherNode with its built-in REST integration. Put the key in secrets.yaml and add this to configuration.yaml.') }}
+                </p>
+                <div class="mt-4 flex justify-end">
+                    <button type="button"
+                            onclick="copyCode('home-assistant-example', this)"
+                            class="rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-700 transition hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">
+                        {{ __('Copy') }}
+                    </button>
+                </div>
+                <pre id="home-assistant-example" class="mt-2 overflow-x-auto rounded-lg bg-slate-950 p-4 text-xs leading-6 text-slate-100"><code>rest:
+  - resource: https://weather.example.com/api/weather/current
+    headers:
+      X-API-Key: !secret weathernode_api_key
+      Accept: application/json
+    scan_interval: 60
+    sensor:
+      - name: WeatherNode temperature
+        unique_id: weathernode_temperature
+        value_template: "@{{ value_json.data.temperature }}"
+        unit_of_measurement: "°C"
+        device_class: temperature
+        state_class: measurement
+      - name: WeatherNode humidity
+        unique_id: weathernode_humidity
+        value_template: "@{{ value_json.data.humidity }}"
+        unit_of_measurement: "%"
+        device_class: humidity
+        state_class: measurement</code></pre>
+                <p class="mt-3 text-xs text-gray-500 dark:text-gray-400">
+                    <code>secrets.yaml</code>: <code>weathernode_api_key: YOUR_API_KEY</code>
+                </p>
+            </div>
+        </details>
+
+        <details class="group border-b border-gray-100 dark:border-gray-700/60">
+            <summary class="flex cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 text-sm font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-gray-700/30">
+                <span>{{ __('Node-RED and Telegraf') }}</span>
+                <svg class="h-5 w-5 text-gray-400 transition group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                </svg>
+            </summary>
+            <div class="border-t border-gray-100 px-5 py-5 dark:border-gray-700/60">
+                <div class="grid gap-6 lg:grid-cols-2">
+                    <div>
+                        <h4 class="text-sm font-semibold text-gray-900 dark:text-white">Node-RED</h4>
+                        <p class="mt-1 text-sm leading-6 text-gray-600 dark:text-gray-300">{{ __('Set an HTTP request node to GET the current endpoint and add these headers in a function node.') }}</p>
+                        <pre class="mt-3 overflow-x-auto rounded-lg bg-slate-950 p-4 text-xs leading-6 text-slate-100"><code>msg.url = "https://weather.example.com/api/weather/current";
+msg.headers = {
+  "Accept": "application/json",
+  "X-API-Key": env.get("WEATHERNODE_API_KEY")
+};
+return msg;</code></pre>
+                    </div>
+                    <div>
+                        <h4 class="text-sm font-semibold text-gray-900 dark:text-white">Telegraf</h4>
+                        <p class="mt-1 text-sm leading-6 text-gray-600 dark:text-gray-300">{{ __('Use the HTTP input plugin with JSON v2 parsing. Keep the key in the Telegraf service environment.') }}</p>
+                        <pre class="mt-3 overflow-x-auto rounded-lg bg-slate-950 p-4 text-xs leading-6 text-slate-100"><code>[[inputs.http]]
+  urls = ["https://weather.example.com/api/weather/current"]
+  interval = "60s"
+  data_format = "json_v2"
+
+  [inputs.http.headers]
+    X-API-Key = "${WEATHERNODE_API_KEY}"
+
+  [[inputs.http.json_v2.object]]
+    path = "data"</code></pre>
+                    </div>
+                </div>
+            </div>
+        </details>
+
+        <details class="group">
+            <summary class="flex cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 text-sm font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-gray-700/30">
+                <span>{{ __('Errors, limits, and safe use') }}</span>
+                <svg class="h-5 w-5 text-gray-400 transition group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                </svg>
+            </summary>
+            <div class="border-t border-gray-100 px-5 py-5 dark:border-gray-700/60">
+                <div class="grid gap-5 md:grid-cols-2">
+                    <div>
+                        <h4 class="text-sm font-semibold text-gray-900 dark:text-white">{{ __('Common responses') }}</h4>
+                        <ul class="mt-3 space-y-2 text-sm text-gray-600 dark:text-gray-300">
+                            <li><code>401</code> {{ __('Key missing, invalid, or revoked') }}</li>
+                            <li><code>403</code> {{ __('Private endpoint called with a public key') }}</li>
+                            <li><code>429</code> {{ __('Rate limit reached. Check the Retry-After header.') }}</li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h4 class="text-sm font-semibold text-gray-900 dark:text-white">{{ __('Good practice') }}</h4>
+                        <ul class="mt-3 list-disc space-y-2 pl-5 text-sm text-gray-600 dark:text-gray-300">
+                            <li>{{ __('Keep private keys out of browser code and URLs.') }}</li>
+                            <li>{{ __('Poll current conditions about once per minute unless your station updates less often.') }}</li>
+                            <li>{{ __('Check the success field because unavailable services can still return HTTP 200.') }}</li>
+                            <li>{{ __('API weather values use canonical metric units.') }}</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </details>
+    </div>
+</section>
+
 <script>
 function toggleApiKeyVisibility(id) {
     const input = document.getElementById(id);
@@ -169,6 +395,19 @@ function copyApiKey(id) {
     input.select();
     input.setSelectionRange(0, 99999);
     navigator.clipboard.writeText(input.value);
+}
+
+function copyCode(id, button) {
+    const code = document.getElementById(id);
+    if (!code) return;
+
+    navigator.clipboard.writeText(code.textContent).then(() => {
+        const originalText = button.textContent;
+        button.textContent = @json(__('Copied'));
+        window.setTimeout(() => {
+            button.textContent = originalText;
+        }, 1500);
+    });
 }
 </script>
 @endsection

--- a/tests/Feature/Admin/ApiDocumentationTest.php
+++ b/tests/Feature/Admin/ApiDocumentationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Route;
+use Tests\TestCase;
+
+class ApiDocumentationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_api_key_page_contains_the_quick_start_and_integration_examples(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $response = $this->actingAs($admin)->get(route('admin.api-keys.index'));
+
+        $response->assertOk();
+        $response->assertSee('Using the WeatherNode API');
+        $response->assertSee('X-API-Key: YOUR_API_KEY');
+        $response->assertSee('https://weather.example.com/api');
+        $response->assertSee('/api/weather/current');
+        $response->assertSee('Home Assistant example');
+        $response->assertSee('Node-RED and Telegraf');
+        $response->assertSee(
+            'https://github.com/'.config('updater.github_repo').'/blob/main/docs/API.md',
+            false,
+        );
+    }
+
+    public function test_api_markdown_documents_every_registered_api_route(): void
+    {
+        $documentation = file_get_contents(base_path('docs/API.md'));
+
+        $this->assertIsString($documentation);
+
+        $apiRoutes = collect(app('router')->getRoutes()->getRoutes())
+            ->filter(fn (Route $route): bool => str_starts_with($route->uri(), 'api/'));
+
+        $this->assertNotEmpty($apiRoutes);
+
+        foreach ($apiRoutes as $route) {
+            $method = collect($route->methods())->first(fn (string $method): bool => $method !== 'HEAD');
+            $documentedRoute = sprintf('| %s | `/%s` |', $method, $route->uri());
+
+            $this->assertStringContainsString(
+                $documentedRoute,
+                $documentation,
+                sprintf('%s /%s is missing from docs/API.md', $method, $route->uri()),
+            );
+        }
+    }
+
+    public function test_api_documentation_uses_plain_punctuation(): void
+    {
+        $page = file_get_contents(resource_path('views/admin/api-keys/index.blade.php'));
+        $documentation = file_get_contents(base_path('docs/API.md'));
+
+        $this->assertIsString($page);
+        $this->assertIsString($documentation);
+        $this->assertStringNotContainsString('—', $page);
+        $this->assertStringNotContainsString('—', $documentation);
+        $this->assertStringNotContainsString('meteouitgeest.nl', strtolower($page.$documentation));
+        $this->assertStringNotContainsString("url('/api", $page);
+    }
+}


### PR DESCRIPTION
Your API documentation work, moved onto its own branch.

It had been committed on top of the tile-cache branch, so it was travelling with #40 and holding it up: the `curl -H "X-API-Key: YOUR_API_KEY"` examples trip gitleaks' `curl-auth-header` rule, which failed the secret scan on that PR. Splitting it out let #40 merge and keeps this reviewable on its own.

Contents are unchanged from the original commit: `docs/API.md`, the API keys admin view, the README link, and `ApiDocumentationTest`.

Added one commit on top: the two files carrying curl examples are allowlisted in `.gitleaks.toml`, in the same style as the entries already there. Confirmed this does not blunt the scan by dropping a private key into the same directory, which is still detected.

325 tests pass.