### PR TITLE
Reclaim expired file cache entries, and stop the entrypoint forking a chmod per file

### DIFF
--- a/app/Console/Commands/CleanExpiredCache.php
+++ b/app/Console/Commands/CleanExpiredCache.php
@@ -93,20 +93,20 @@ class CleanExpiredCache extends Command
         $liveCount = 0;
 
         foreach ($this->cacheFiles($path) as $file) {
-            $expiration = $this->readExpiration($file->getPathname());
+            $entry = $this->readEntry($file->getPathname());
 
-            // Not a cache payload (e.g. a .gitignore) - leave it alone.
-            if ($expiration === null) {
+            // Not a cache payload (e.g. a .gitignore), or gone already - leave it alone.
+            if ($entry === null) {
                 continue;
             }
 
-            if ($expiration > $now) {
+            if ($entry['expires'] > $now) {
                 $liveCount++;
                 continue;
             }
 
             $expiredCount++;
-            $expiredBytes += $file->getSize();
+            $expiredBytes += $entry['size'];
 
             if (!$isDryRun) {
                 @unlink($file->getPathname());
@@ -169,8 +169,14 @@ class CleanExpiredCache extends Command
     /**
      * The file store writes a 10 digit UNIX timestamp as the first 10 bytes of
      * every entry (9999999999 for forever). Anything else is not one of ours.
+     *
+     * Expiry and size come from one open handle on purpose. A second look at
+     * the path would be a second chance for the file to have gone, and the
+     * app deletes these same expired entries itself whenever one is read.
+     *
+     * @return array{expires: int, size: int}|null
      */
-    private function readExpiration(string $file): ?int
+    private function readEntry(string $file): ?array
     {
         $handle = @fopen($file, 'rb');
 
@@ -179,13 +185,17 @@ class CleanExpiredCache extends Command
         }
 
         $header = fread($handle, 10);
+        $stat = fstat($handle);
         fclose($handle);
 
         if (!is_string($header) || strlen($header) !== 10 || !ctype_digit($header)) {
             return null;
         }
 
-        return (int) $header;
+        return [
+            'expires' => (int) $header,
+            'size' => (int) ($stat['size'] ?? 0),
+        ];
     }
 
     private function removeEmptyDirectories(string $path): int

--- a/app/Console/Commands/CleanExpiredCache.php
+++ b/app/Console/Commands/CleanExpiredCache.php
@@ -2,10 +2,15 @@
 
 namespace App\Console\Commands;
 
+use FilesystemIterator;
+use Generator;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Artisan;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
 
 class CleanExpiredCache extends Command
 {
@@ -70,8 +75,156 @@ class CleanExpiredCache extends Command
     
     private function cleanFileCache(bool $isDryRun): int
     {
-        $this->info('File cache driver: expired files are automatically ignored.');
-        $this->info('No manual cleanup needed - Laravel handles this automatically.');
+        // Expired file cache entries are ignored on read, but they are only
+        // unlinked if that same key is read again (FileStore::getPayload calls
+        // forget()). A key that is written, expires, and is never requested
+        // again stays on disk forever, so the cache directory grows without
+        // limit. Sweep it here instead.
+        $path = $this->fileCachePath();
+
+        if (!is_dir($path)) {
+            $this->info("File cache directory does not exist yet: {$path}");
+            return 0;
+        }
+
+        $now = time();
+        $expiredCount = 0;
+        $expiredBytes = 0;
+        $liveCount = 0;
+
+        foreach ($this->cacheFiles($path) as $file) {
+            $expiration = $this->readExpiration($file->getPathname());
+
+            // Not a cache payload (e.g. a .gitignore) - leave it alone.
+            if ($expiration === null) {
+                continue;
+            }
+
+            if ($expiration > $now) {
+                $liveCount++;
+                continue;
+            }
+
+            $expiredCount++;
+            $expiredBytes += $file->getSize();
+
+            if (!$isDryRun) {
+                @unlink($file->getPathname());
+            }
+        }
+
+        if ($expiredCount === 0) {
+            $this->info('No expired cache entries found.');
+            $this->line("Remaining cache entries: {$liveCount}");
+            return 0;
+        }
+
+        $size = $this->formatBytes($expiredBytes);
+
+        if ($isDryRun) {
+            $this->info("Would delete {$expiredCount} expired cache entries ({$size}).");
+            $this->line('Run without --dry-run to actually delete them.');
+            return 0;
+        }
+
+        $this->info("Deleted {$expiredCount} expired cache entries ({$size}).");
+
+        // Keys are hashed into two levels of directories that are never removed
+        // once empty. Each one costs an inode and a block, and in Docker they
+        // are walked by the entrypoint on every container start.
+        $removedDirectories = $this->removeEmptyDirectories($path);
+
+        if ($removedDirectories > 0) {
+            $this->line("Removed {$removedDirectories} empty cache directories.");
+        }
+
+        $this->line("Remaining cache entries: {$liveCount}");
+
         return 0;
+    }
+
+    private function fileCachePath(): string
+    {
+        $store = config('cache.default');
+
+        return (string) config("cache.stores.{$store}.path", storage_path('framework/cache/data'));
+    }
+
+    /**
+     * @return Generator<SplFileInfo>
+     */
+    private function cacheFiles(string $path): Generator
+    {
+        $entries = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($entries as $entry) {
+            if ($entry->isFile()) {
+                yield $entry;
+            }
+        }
+    }
+
+    /**
+     * The file store writes a 10 digit UNIX timestamp as the first 10 bytes of
+     * every entry (9999999999 for forever). Anything else is not one of ours.
+     */
+    private function readExpiration(string $file): ?int
+    {
+        $handle = @fopen($file, 'rb');
+
+        if ($handle === false) {
+            return null;
+        }
+
+        $header = fread($handle, 10);
+        fclose($handle);
+
+        if (!is_string($header) || strlen($header) !== 10 || !ctype_digit($header)) {
+            return null;
+        }
+
+        return (int) $header;
+    }
+
+    private function removeEmptyDirectories(string $path): int
+    {
+        $removed = 0;
+
+        // CHILD_FIRST so a directory whose only contents were empty
+        // subdirectories is collapsed in the same pass. rmdir() refuses
+        // non-empty directories, which is the guard against deleting live data.
+        $entries = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($entries as $entry) {
+            if ($entry->isDir() && !$entry->isLink() && @rmdir($entry->getPathname())) {
+                $removed++;
+            }
+        }
+
+        return $removed;
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return "{$bytes} B";
+        }
+
+        $value = $bytes / 1024;
+
+        foreach (['KB', 'MB', 'GB'] as $unit) {
+            if ($value < 1024 || $unit === 'GB') {
+                return sprintf('%.1f %s', $value, $unit);
+            }
+
+            $value /= 1024;
+        }
+
+        return "{$bytes} B";
     }
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -164,9 +164,13 @@ ensure_writable_paths() {
 
     chmod 775 "$APP_DIR/storage" "$APP_DIR/bootstrap/cache" || true
     [ -n "$SQLITE_DIR" ] && [ -d "$SQLITE_DIR" ] && chmod 775 "$SQLITE_DIR" || true
-    find "$APP_DIR/storage" -type d -exec chmod 775 {} \; || true
-    find "$APP_DIR/storage" -type f -exec chmod 664 {} \; || true
-    find "$APP_DIR/bootstrap/cache" -type f -exec chmod 664 {} \; || true
+    # -exec ... + batches the paths into as few chmod calls as possible. With
+    # \; it is one fork per file, and storage/ holds the file cache: an install
+    # with 45k cached entries spent ~2 minutes here on every container recreate,
+    # before the first log line after this function.
+    find "$APP_DIR/storage" -type d -exec chmod 775 {} + || true
+    find "$APP_DIR/storage" -type f -exec chmod 664 {} + || true
+    find "$APP_DIR/bootstrap/cache" -type f -exec chmod 664 {} + || true
     [ -f "$SQLITE_PATH" ] && chmod 664 "$SQLITE_PATH" || true
 }
 

--- a/tests/Unit/Console/CleanExpiredCacheCommandTest.php
+++ b/tests/Unit/Console/CleanExpiredCacheCommandTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console;
+
+use FilesystemIterator;
+use Illuminate\Support\Facades\Artisan;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Tests\TestCase;
+
+class CleanExpiredCacheCommandTest extends TestCase
+{
+    private string $cachePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cachePath = storage_path('framework/testing/cache-'.uniqid());
+        mkdir($this->cachePath, 0775, true);
+
+        config([
+            'cache.default' => 'file',
+            'cache.stores.file.driver' => 'file',
+            'cache.stores.file.path' => $this->cachePath,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteDirectory($this->cachePath);
+
+        parent::tearDown();
+    }
+
+    public function test_it_deletes_expired_entries_and_keeps_live_ones(): void
+    {
+        $this->writeEntry('aa/bb/expired-one', time() - 60);
+        $this->writeEntry('aa/bb/expired-two', time() - 3600);
+        $this->writeEntry('cc/dd/live', time() + 300);
+
+        $exitCode = Artisan::call('cache:clean-expired');
+        $output = Artisan::output();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('Deleted 2 expired cache entries', $output);
+        $this->assertStringContainsString('Remaining cache entries: 1', $output);
+
+        $this->assertFileDoesNotExist($this->cachePath.'/aa/bb/expired-one');
+        $this->assertFileDoesNotExist($this->cachePath.'/aa/bb/expired-two');
+        $this->assertFileExists($this->cachePath.'/cc/dd/live');
+    }
+
+    public function test_it_keeps_entries_stored_forever(): void
+    {
+        // Illuminate\Cache\FileStore::forever() writes 9999999999.
+        $this->writeEntry('aa/bb/forever', 9999999999);
+
+        Artisan::call('cache:clean-expired');
+
+        $this->assertStringContainsString('No expired cache entries found.', Artisan::output());
+        $this->assertFileExists($this->cachePath.'/aa/bb/forever');
+    }
+
+    public function test_dry_run_reports_without_deleting(): void
+    {
+        $this->writeEntry('aa/bb/expired', time() - 60);
+
+        Artisan::call('cache:clean-expired', ['--dry-run' => true]);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Would delete 1 expired cache entries', $output);
+        $this->assertFileExists($this->cachePath.'/aa/bb/expired');
+    }
+
+    public function test_it_leaves_files_that_are_not_cache_payloads_alone(): void
+    {
+        file_put_contents($this->cachePath.'/.gitignore', "*\n!.gitignore\n");
+        $this->writeEntry('aa/bb/expired', time() - 60);
+
+        Artisan::call('cache:clean-expired');
+
+        $this->assertFileExists($this->cachePath.'/.gitignore');
+        $this->assertFileDoesNotExist($this->cachePath.'/aa/bb/expired');
+    }
+
+    public function test_it_removes_directories_left_empty(): void
+    {
+        $this->writeEntry('aa/bb/expired', time() - 60);
+        $this->writeEntry('cc/dd/live', time() + 300);
+
+        Artisan::call('cache:clean-expired');
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Removed 2 empty cache directories.', $output);
+        $this->assertDirectoryDoesNotExist($this->cachePath.'/aa');
+        $this->assertDirectoryExists($this->cachePath.'/cc/dd');
+    }
+
+    public function test_it_handles_a_cache_directory_that_does_not_exist_yet(): void
+    {
+        $missing = $this->cachePath.'/not-created-yet';
+        config(['cache.stores.file.path' => $missing]);
+
+        $exitCode = Artisan::call('cache:clean-expired');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('File cache directory does not exist yet', Artisan::output());
+    }
+
+    /**
+     * Mirrors the on-disk format of Illuminate\Cache\FileStore: a 10 digit
+     * expiry timestamp followed by the serialized value.
+     */
+    private function writeEntry(string $relativePath, int $expiration): void
+    {
+        $fullPath = $this->cachePath.'/'.$relativePath;
+        $directory = dirname($fullPath);
+
+        if (!is_dir($directory)) {
+            mkdir($directory, 0775, true);
+        }
+
+        file_put_contents($fullPath, $expiration.serialize('cached value'));
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $entries = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($entries as $entry) {
+            $entry->isDir() ? @rmdir($entry->getPathname()) : @unlink($entry->getPathname());
+        }
+
+        @rmdir($path);
+    }
+}

--- a/tests/Unit/Console/CleanExpiredCacheCommandTest.php
+++ b/tests/Unit/Console/CleanExpiredCacheCommandTest.php
@@ -114,6 +114,42 @@ class CleanExpiredCacheCommandTest extends TestCase
      * Mirrors the on-disk format of Illuminate\Cache\FileStore: a 10 digit
      * expiry timestamp followed by the serialized value.
      */
+    /** The reported size comes from the same handle the expiry is read from. */
+    public function test_it_reports_the_size_of_what_it_deleted(): void
+    {
+        $this->writeEntry('aa/bb/expired-one', time() - 60);
+        $this->writeEntry('aa/bb/expired-two', time() - 60);
+
+        $expectedBytes = filesize($this->cachePath.'/aa/bb/expired-one')
+            + filesize($this->cachePath.'/aa/bb/expired-two');
+
+        Artisan::call('cache:clean-expired');
+
+        $this->assertStringContainsString("({$expectedBytes} B)", Artisan::output());
+    }
+
+    /**
+     * The app unlinks an expired entry itself whenever one is read, so a sweep
+     * of expired entries can meet a file that has just gone. Skip it and carry
+     * on rather than aborting the run partway through.
+     */
+    public function test_an_entry_it_cannot_read_does_not_stop_the_sweep(): void
+    {
+        $this->writeEntry('aa/bb/expired', time() - 60);
+        $this->writeEntry('aa/bb/unreadable', time() - 60);
+        chmod($this->cachePath.'/aa/bb/unreadable', 0000);
+
+        if (is_readable($this->cachePath.'/aa/bb/unreadable')) {
+            $this->markTestSkipped('Running as root, so file permissions do not apply.');
+        }
+
+        $exitCode = Artisan::call('cache:clean-expired');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('Deleted 1 expired cache entries', Artisan::output());
+        $this->assertFileDoesNotExist($this->cachePath.'/aa/bb/expired');
+    }
+
     private function writeEntry(string $relativePath, int $expiration): void
     {
         $fullPath = $this->cachePath.'/'.$relativePath;


### PR DESCRIPTION
Fixes #43.

Two independent changes for the two halves of that issue: the file cache that grows forever, and the entrypoint that walks it one fork at a time.

## 1. `cache:clean-expired` actually sweeps the file store

`cleanFileCache()` was a no-op reporting *"expired files are automatically ignored"*. They are ignored on read, but `FileStore::getPayload()` unlinks an entry only when that same key is read again, so a key that is written, expires, and is never requested again stays on disk permanently.

The command now reads the 10 byte expiry header that begins every file store entry and deletes what has expired, then removes the hashed directories left empty behind it.

- Entries stored forever (`9999999999`) are kept.
- Files that are not cache payloads — a `.gitignore`, anything without a 10 digit numeric header — are skipped rather than deleted.
- `--dry-run` reports without touching anything.
- `rmdir()` refuses non-empty directories, which is what stops the directory pass from ever removing live data.
- The `cache-cleanup` scheduled task already runs this command nightly, so nothing needs new scheduling or configuration.

## 2. `-exec … +` in `ensure_writable_paths()`

The three `find … -exec chmod {} \;` calls fork once per path. `-exec … +` batches them, and keeps the directory/file mode split that `chmod -R` cannot express.

## Verification

Measured on the install from #43 — a 2 core VM, PHP 8.4, MySQL 8, its cache directory copied out of the live volume so the real data was untouched.

**The sweep, against 45,477 real entries:**

```
Cache driver: file
Deleted 44709 expired cache entries (27.2 MB).
Removed 32069 empty cache directories.
Remaining cache entries: 768
sweep took 5178 ms
after: files=768 dirs=1007
3.5M    storage/framework/cache/data
```

180 MB → 3.5 MB, 45,477 files → 768, in five seconds. The 768 survivors are the live entries.

**The chmod change, on a synthetic 45,000 file tree in the same image:**

| | |
|---|---|
| `-exec chmod 664 {} \;` | 53,764 ms |
| `-exec chmod 664 {} +` | 443 ms |

121× on the file pass alone; the real startup also walks the directories and `bootstrap/cache`.

**Tests:** six new cases in `tests/Unit/Console/CleanExpiredCacheCommandTest.php` covering expired/live entries, forever entries, `--dry-run`, non-payload files, empty-directory pruning, and a cache directory that does not exist yet. Full unit suite green:

```
$ vendor/bin/phpunit tests/Unit
Tests: 145, Assertions: 399, Skipped: 1.
```

`sh -n docker/entrypoint.sh` passes.

## A note on Pint

I did not run Pint over these files. `pint --test app/ tests/` reports **219 pre-existing style issues across 292 files** on `main`, including in `CleanExpiredCache.php` itself (`class_attributes_separation`, `not_operator_with_successor_space`), so formatting my two files would have made them inconsistent with everything around them and buried the change in unrelated diff. The new code follows the conventions already used in the file. Happy to run it if you would rather have these files clean, or as part of a separate repo-wide pass.
