### PR TITLE
Show newest radar frame when the dashboard animation is disabled

### DIFF
--- a/resources/js/pages/dashboard.js
+++ b/resources/js/pages/dashboard.js
@@ -1975,6 +1975,16 @@ function weatherDashboard() {
                     return timeLabel;
                 },
 
+                newestObservedRadarFrameIndex() {
+                    for (let i = this._radarFrames.length - 1; i >= 0; i--) {
+                        if (this._radarFrames[i]?.source !== 'future_provider') {
+                            return i;
+                        }
+                    }
+
+                    return 0;
+                },
+
                 showRadarFrame(index) {
                     if (!this._radarMap || !this._radarFrames.length || !window.L) {
                         return;
@@ -2127,9 +2137,7 @@ function weatherDashboard() {
                     this.stopRadarAnimation();
 
                     if (document.body.classList.contains('theme-flat') || this._radarFrames.length <= 1) {
-                        if (this._radarFrames.length > 1) {
-                            this._radarCurrentFrameIndex = this._radarFrames.length - 1;
-                        }
+                        this._radarCurrentFrameIndex = this.newestObservedRadarFrameIndex();
                         this.showRadarFrame(this._radarCurrentFrameIndex);
                         return;
                     }

--- a/resources/js/pages/dashboard.js
+++ b/resources/js/pages/dashboard.js
@@ -2125,11 +2125,16 @@ function weatherDashboard() {
 
                 startRadarAnimation() {
                     this.stopRadarAnimation();
-                    this.showRadarFrame(this._radarCurrentFrameIndex);
 
                     if (document.body.classList.contains('theme-flat') || this._radarFrames.length <= 1) {
+                        if (this._radarFrames.length > 1) {
+                            this._radarCurrentFrameIndex = this._radarFrames.length - 1;
+                        }
+                        this.showRadarFrame(this._radarCurrentFrameIndex);
                         return;
                     }
+
+                    this.showRadarFrame(this._radarCurrentFrameIndex);
 
                     const frameDelay = Math.max(250, Number(cfg.rainviewerFrameDelay || 1000));
                     this._radarAnimationInterval = setInterval(() => {


### PR DESCRIPTION
Fixes #49.

### Problem

`startRadarAnimation()` returns early when the flat theme is active (or only one frame is available), but it calls `showRadarFrame(this._radarCurrentFrameIndex)` *before* that check. `_radarCurrentFrameIndex` is `0` at init (`:1720`) and reset to `0` after every refresh (`:1813`), and the frame list runs oldest → newest — so the widget parks on the start of the 2-hour history window and returns there on each refresh.

On a flat-theme install the dashboard therefore shows radar from two hours ago, permanently, with nothing indicating it isn't current.

### Change

Park on the most recent frame when the animation can't run. The animating path is untouched and still starts from index 0.

```js
if (document.body.classList.contains('theme-flat') || this._radarFrames.length <= 1) {
    if (this._radarFrames.length > 1) {
        this._radarCurrentFrameIndex = this._radarFrames.length - 1;
    }
    this.showRadarFrame(this._radarCurrentFrameIndex);
    return;
}
```

The `length > 1` guard keeps the index at `0` for the single-frame case, where `0` is already the newest frame. `showRadarFrame()` independently no-ops on an empty frame list (`:1979`), so the empty case behaves exactly as before.

### Verification

Applied against a live install (flat theme, 13 frames at 10-minute steps):

| | Before | After |
|---|---|---|
| Frame index shown | 0 | 12 |
| Clock badge | 11:30 | **13:30** |
| Newest frame available | 13:30 | 13:30 |
| Animation interval created | no | no (unchanged) |

The flat theme's intent — no motion — is preserved; only which still frame is shown changes.
