### PR TITLE
Fix dashboard radar map zoom locking up after the first zoom

### DIFF
--- a/resources/js/pages/dashboard.js
+++ b/resources/js/pages/dashboard.js
@@ -1698,6 +1698,7 @@ function weatherDashboard() {
                         attributionControl: false,
                         maxZoom: 7,
                         minZoom: 0,
+                        zoomAnimation: false,
                     });
 
                     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {


### PR DESCRIPTION
Fixes #50.

### Problem

The dashboard radar widget's zoom buttons do nothing, and the first zoom attempt wedges the map permanently — `setZoom()` and `setView()` stop working too.

`initRadarWidgetObserver()` (`:1655`) creates the map from an IntersectionObserver with `rootMargin: '250px 0px'`, so `L.map()` runs while the container is still off-screen. Under the flat theme, `resources/css/app.css:44-49` also applies `transition: none !important` to every element.

Leaflet's animated zoom sets `_animatingZoom = true`, adds `.leaflet-zoom-anim`, and waits for a `transitionend` on the map pane to commit the zoom via `_onZoomTransitionEnd()`. In that combination the event never arrives, so the flag stays latched and the first line of `_tryAnimatedZoom()` swallows every later zoom:

```js
_tryAnimatedZoom(center, zoom, options) {
    if (this._animatingZoom) { return true; }
```

Leaflet's own 250 ms `setTimeout(this._onZoomTransitionEnd, 250)` fallback in `_animateZoom()` does not rescue it — verified stuck 5 s later.

### Change

Create the widget map with `zoomAnimation: false`, removing the dependency on `transitionend` entirely. Instant zoom is a reasonable fit here regardless: the widget is a 329×185 panel, and under the flat theme the animation would be suppressed by the CSS anyway.

### Verification

Fresh load, page visible, Leaflet 1.9.4:

| Test | Result |
|---|---|
| As shipped, zoom out | `zoomstart` fires, `zoomend` never does, zoom stays 7 after 5 s, `_animatingZoom` still `true` |
| Manually clear `_animatingZoom`, retry | re-wedges immediately |
| `setZoom(5)` / `setView(…, 4)` | no effect |
| Radar page map (same CSS, created on-screen) | works — 7 → 6 → 5 |
| Widget map recreated on-screen, default options | works — 7 → 6 |
| **Widget map with `zoomAnimation: false`** | **works — 7 → 6 → 5 → 6, `zoomend` every time** |

The middle rows show why only this widget is affected: neither the CSS nor the off-screen creation is sufficient alone.

### Not addressed here

`radarCanZoomIn()` is `getZoom() < getMaxZoom()`, and the map opens at `maxZoom` (7) on a default install, so "+" starts disabled. With this fix that's ordinary at-max-zoom behaviour — zoom out and it re-enables — but it may still be worth letting `maxZoom` exceed the default zoom. Left out of this PR since it changes tile-request behaviour and the basemap layer is capped at 7 as well. Noted in #50.
