### PR TITLE
Fix sensor failure alerts never being sent

### DIFF
--- a/app/Console/Commands/CheckSensorHealth.php
+++ b/app/Console/Commands/CheckSensorHealth.php
@@ -2,12 +2,12 @@
 
 namespace App\Console\Commands;
 
+use App\Services\Notifications\NotificationDispatcher;
 use App\Services\Weather\SensorTrackerService;
 use Illuminate\Console\Command;
 use App\Models\WeatherReading;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
 use App\Models\Setting;
 
 class CheckSensorHealth extends Command
@@ -103,11 +103,18 @@ class CheckSensorHealth extends Command
 
         $trackDays = (int) Setting::getValue('sensor_health.track_days', 7);
         $trackDays = max(1, min(30, $trackDays));
-        $failMinutes = (int) Setting::getValue('sensor_health.fail_minutes', 120);
+        $failMinutes = (int) Setting::getValue('sensor_health.fail_minutes', 30);
         $failMinutes = max(15, min(10080, $failMinutes)); // 15 min .. 7 days
 
-        $tracker = app(SensorTrackerService::class);
-        $failed = $tracker->getFailedSensors($trackDays, $failMinutes);
+        // One scan drives both the alert and the states the admin UI reads.
+        $states = app(SensorTrackerService::class)->refreshSensorStates($trackDays, $failMinutes);
+
+        $failed = [];
+        foreach ($states as $state) {
+            if ($state['state'] === 'failed') {
+                $failed[] = ['id' => $state['id'], 'last_seen' => $state['last_seen']];
+            }
+        }
 
         $failedForCache = array_map(function ($item) {
             return [
@@ -289,41 +296,20 @@ class CheckSensorHealth extends Command
     }
 
     /**
-     * Send alert via configured notification channel
+     * Send alert through the shared notification channel, so the recipient
+     * configured in Admin → Settings → Notifications applies here too.
      */
     private function sendAlert(string $subject, string $message)
     {
-        // Log to Laravel log
         Log::warning($subject . ': ' . $message);
 
-        // Get notification settings
-        $alertEmail = Setting::getValue('alerts.email');
-        $alertsEnabled = Setting::getValue('alerts.enabled', false);
+        $delivered = app(NotificationDispatcher::class)
+            ->send($subject, ['message' => $message], 'sensor_offline');
 
-        if (!$alertsEnabled) {
-            $this->warn('Alerts are disabled in settings. Enable in admin panel to receive notifications.');
-            return;
-        }
-
-        if (!$alertEmail) {
-            $this->warn('No alert email configured. Set alerts.email in admin panel.');
-            return;
-        }
-
-        // Send email alert
-        try {
-            Mail::raw($message, function ($mail) use ($subject, $alertEmail) {
-                $mail->to($alertEmail)
-                     ->subject("[WeatherNode] {$subject}");
-            });
-
-            $this->info("Alert sent to: {$alertEmail}");
-        } catch (\Exception $e) {
-            $this->error("Failed to send email alert: " . $e->getMessage());
-            Log::error('Failed to send sensor health alert email', [
-                'error' => $e->getMessage(),
-                'subject' => $subject,
-            ]);
+        if ($delivered) {
+            $this->info("Alert notification sent: {$subject}");
+        } else {
+            $this->warn("Alert not delivered (check Admin → Settings → Notifications): {$subject}");
         }
     }
 }

--- a/app/Console/Commands/CheckSensorHealth.php
+++ b/app/Console/Commands/CheckSensorHealth.php
@@ -144,30 +144,57 @@ class CheckSensorHealth extends Command
         }
     }
 
+    private const ALERTED_CACHE_KEY = 'alert_sent_sensor_failures';
+
+    /**
+     * Sensor IDs we have already sent an alert for. Older builds stored a bare
+     * boolean here; treat that as "nothing recorded" so it re-alerts once.
+     */
+    private function alreadyAlertedSensorIds(): array
+    {
+        $alerted = Cache::get(self::ALERTED_CACHE_KEY, []);
+
+        return is_array($alerted) ? $alerted : [];
+    }
+
     private function sendSensorFailureAlertIfNeeded(array $failed, string $details): void
     {
-        $cacheKey = 'alert_sent_sensor_failures';
+        $alerted = $this->alreadyAlertedSensorIds();
+        $currentIds = array_column($failed, 'id');
 
-        if (!Cache::get($cacheKey, false)) {
-            $this->sendAlert(
-                (string) __("One or more weather sensors have stopped reporting"),
-                $details
+        // Only stay quiet while the failing set is one we have already reported;
+        // a newly failing sensor is worth another alert.
+        if (empty(array_diff($currentIds, $alerted))) {
+            return;
+        }
+
+        // Record the alert only once it has actually gone out, otherwise a
+        // failure detected before notifications are configured is never sent.
+        $delivered = $this->sendAlert(
+            (string) __("One or more weather sensors have stopped reporting"),
+            $details
+        );
+
+        if ($delivered) {
+            Cache::put(
+                self::ALERTED_CACHE_KEY,
+                array_values(array_unique(array_merge($alerted, $currentIds))),
+                now()->addHours(24)
             );
-            Cache::put($cacheKey, true, now()->addHours(24));
         }
     }
 
     private function clearSensorFailureAlertIfNeeded(): void
     {
-        $cacheKey = 'alert_sent_sensor_failures';
-
-        if (Cache::get($cacheKey, false)) {
-            $this->sendAlert(
-                (string) __("Weather sensors back to normal"),
-                (string) __("All previously failing sensors are reporting again.")
-            );
-            Cache::forget($cacheKey);
+        if ($this->alreadyAlertedSensorIds() === [] && !Cache::has(self::ALERTED_CACHE_KEY)) {
+            return;
         }
+
+        $this->sendAlert(
+            (string) __("Weather sensors back to normal"),
+            (string) __("All previously failing sensors are reporting again.")
+        );
+        Cache::forget(self::ALERTED_CACHE_KEY);
     }
 
     private function checkForecastData()
@@ -299,7 +326,7 @@ class CheckSensorHealth extends Command
      * Send alert through the shared notification channel, so the recipient
      * configured in Admin → Settings → Notifications applies here too.
      */
-    private function sendAlert(string $subject, string $message)
+    private function sendAlert(string $subject, string $message): bool
     {
         Log::warning($subject . ': ' . $message);
 
@@ -311,5 +338,7 @@ class CheckSensorHealth extends Command
         } else {
             $this->warn("Alert not delivered (check Admin → Settings → Notifications): {$subject}");
         }
+
+        return $delivered;
     }
 }

--- a/app/Console/Commands/FetchWeatherData.php
+++ b/app/Console/Commands/FetchWeatherData.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Models\DailySummary;
 use App\Models\ClimateRecord;
 use App\Models\WeatherReading;
+use App\Services\Notifications\NotificationDispatcher;
 use App\Services\Weather\EcowittService;
 use App\Services\Weather\LocalFiles\LocalFileSourceService;
 use App\Services\Weather\Normalization\WeatherReadingWriter;
@@ -15,7 +16,6 @@ use App\Services\Weather\Sources\WeatherLinkV1Adapter;
 use App\Services\Weather\Sources\WundergroundAdapter;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Cache;
 use App\Models\Setting;
 
@@ -514,131 +514,8 @@ class FetchWeatherData extends Command
      */
     private function sendAlert(string $subject, array $details): void
     {
-        // Check if notifications are enabled
-        $notificationsEnabled = Setting::getValue('notifications.enabled', false);
-        if (!$notificationsEnabled) {
-            Log::warning("Alert (notifications disabled): {$subject}", $details);
-            return;
-        }
-
-        // Check if this alert type is enabled
-        $alertType = $this->getAlertType($subject);
-        if ($alertType && !Setting::getValue("notifications.{$alertType}", true)) {
-            Log::info("Alert suppressed (type disabled): {$subject}", $details);
-            return;
-        }
-
-        // Get notification method and recipients
-        $method = Setting::getValue('notifications.method', 'email');
-        $email = Setting::getValue('notifications.email', '');
-        $webhookUrl = Setting::getValue('notifications.webhook_url', '');
-
-        // Check if at least one method is configured
-        $sendEmail = in_array($method, ['email', 'both'], true) && !empty($email);
-        $sendWebhook = in_array($method, ['webhook', 'both'], true) && !empty($webhookUrl);
-
-        if (!$sendEmail && !$sendWebhook) {
-            Log::warning("Alert (no notification method configured): {$subject}", $details);
-            return;
-        }
-
-        // Rate limit: Don't spam - only send one alert per hour per issue type
-        $alertKey = "alert_" . md5($subject . serialize($details));
-        $lastAlert = Cache::get($alertKey);
-        
-        if ($lastAlert && $lastAlert->diffInMinutes(now()) < 60) {
-            // Already alerted recently, just log
-            Log::info("Alert suppressed (rate limit): {$subject}", $details);
-            return;
-        }
-
-        $success = false;
-
-        // Send email notification
-        if ($sendEmail) {
-            try {
-                $message = "Weather Station Alert: {$subject}\n\n";
-                $message .= "Details:\n";
-                foreach ($details as $key => $value) {
-                    $message .= "  {$key}: " . (is_array($value) ? json_encode($value) : $value) . "\n";
-                }
-                $message .= "\nTime: " . now()->toDateTimeString() . "\n";
-                $message .= "\nPlease check your weather station configuration and connection.";
-
-                Mail::raw($message, function ($mail) use ($email, $subject) {
-                    $mail->to($email)
-                         ->subject("[Weather Station] {$subject}");
-                });
-
-                $success = true;
-                Log::info("Alert email sent: {$subject}", ['email' => $email, 'details' => $details]);
-                $this->info("📧 Alert notification sent to {$email}");
-            } catch (\Exception $e) {
-                Log::error('Failed to send alert email', [
-                    'error' => $e->getMessage(),
-                    'subject' => $subject,
-                    'email' => $email,
-                ]);
-                $this->warn("⚠️  Failed to send alert email: {$e->getMessage()}");
-            }
-        }
-
-        // Send webhook notification
-        if ($sendWebhook) {
-            try {
-                $payload = [
-                    'subject' => $subject,
-                    'details' => $details,
-                    'timestamp' => now()->toIso8601String(),
-                    'alert_type' => $alertType,
-                ];
-
-                $ch = curl_init($webhookUrl);
-                curl_setopt_array($ch, [
-                    CURLOPT_POST => true,
-                    CURLOPT_POSTFIELDS => json_encode($payload),
-                    CURLOPT_HTTPHEADER => [
-                        'Content-Type: application/json',
-                        'User-Agent: WeatherNode/1.0',
-                    ],
-                    CURLOPT_RETURNTRANSFER => true,
-                    CURLOPT_TIMEOUT => 10,
-                    CURLOPT_SSL_VERIFYPEER => false, // Allow self-signed certs
-                ]);
-
-                $response = curl_exec($ch);
-                $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-                $error = curl_error($ch);
-                curl_close($ch);
-
-                if ($httpCode >= 200 && $httpCode < 300) {
-                    $success = true;
-                    Log::info("Alert webhook sent: {$subject}", ['webhook' => $webhookUrl, 'details' => $details]);
-                    $this->info("🔗 Alert webhook sent to {$webhookUrl}");
-                } else {
-                    Log::error('Webhook returned error', [
-                        'http_code' => $httpCode,
-                        'response' => $response,
-                        'error' => $error,
-                        'subject' => $subject,
-                        'webhook' => $webhookUrl,
-                    ]);
-                    $this->warn("⚠️  Webhook returned HTTP {$httpCode}");
-                }
-            } catch (\Exception $e) {
-                Log::error('Failed to send webhook', [
-                    'error' => $e->getMessage(),
-                    'subject' => $subject,
-                    'webhook' => $webhookUrl,
-                ]);
-                $this->warn("⚠️  Failed to send webhook: {$e->getMessage()}");
-            }
-        }
-
-        // Mark as alerted if at least one method succeeded
-        if ($success) {
-            Cache::put($alertKey, now(), now()->addHours(1));
-        }
+        app(NotificationDispatcher::class)
+            ->send($subject, $details, $this->getAlertType($subject));
     }
 
     /**

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -7,6 +7,7 @@ use App\Models\WeatherReading;
 use App\Models\DailySummary;
 use App\Models\Setting;
 use App\Models\User;
+use App\Services\Weather\SensorTrackerService;
 use Illuminate\Support\Facades\DB;
 
 class DashboardController extends Controller
@@ -33,9 +34,10 @@ class DashboardController extends Controller
         // Battery status from most recent reading
         $batteryStatus = $this->parseBatteryStatus($lastReading?->battery_status);
         
-        // Active sensors from most recent reading
-        $activeSensors = $this->getActiveSensors($lastReading);
-        
+        // Every sensor known from the tracking window, with its current state,
+        // so one that has gone quiet stays visible instead of disappearing.
+        $sensorStates = $this->getSensorStates();
+
         // Station info
         $stationInfo = [
             'type' => $lastReading?->station_type,
@@ -51,10 +53,10 @@ class DashboardController extends Controller
         $telemetryData = $telemetryService->collectStationData();
 
         return view('admin.dashboard', compact(
-            'stats', 
-            'recentReadings', 
-            'batteryStatus', 
-            'activeSensors', 
+            'stats',
+            'recentReadings',
+            'batteryStatus',
+            'sensorStates',
             'stationInfo',
             'telemetryEnabled',
             'telemetryLastUpdated',
@@ -154,51 +156,15 @@ class DashboardController extends Controller
     }
 
     /**
-     * Get list of active sensors from reading
+     * Sensor states for display, served from the cache the scheduled health
+     * check refreshes. Scanning the reading window here would cost seconds.
      */
-    private function getActiveSensors(?WeatherReading $reading): array
+    private function getSensorStates(): array
     {
-        if (!$reading) {
-            return [];
-        }
+        $trackDays = max(1, min(30, (int) Setting::getValue('sensor_health.track_days', 7)));
+        $failMinutes = max(15, min(10080, (int) Setting::getValue('sensor_health.fail_minutes', 30)));
 
-        $sensors = [];
-
-        // Core sensors
-        if ($reading->temperature !== null) $sensors[] = 'Buiten temp/hum';
-        if ($reading->temperature_indoor !== null) $sensors[] = 'Binnen temp/hum';
-        if ($reading->pressure_rel !== null) $sensors[] = 'Barometer';
-        if ($reading->wind_speed !== null) $sensors[] = 'Wind';
-        if ($reading->rain_daily !== null) $sensors[] = 'Regen';
-        if ($reading->uv_index !== null) $sensors[] = 'UV sensor';
-        if ($reading->solar_radiation !== null) $sensors[] = 'Solar sensor';
-        if ($reading->lightning_distance !== null || $reading->lightning_count !== null) $sensors[] = 'Bliksem (WH57)';
-        
-        // Extra temp sensors
-        for ($i = 1; $i <= 8; $i++) {
-            if ($reading->{"temp_{$i}"} !== null) {
-                $sensors[] = "Extra temp #{$i}";
-            }
-        }
-        
-        // Soil sensors
-        for ($i = 1; $i <= 8; $i++) {
-            if ($reading->{"soil_moisture_{$i}"} !== null) {
-                $sensors[] = "Grond #{$i}";
-            }
-        }
-        
-        // PM2.5 sensors
-        for ($i = 1; $i <= 4; $i++) {
-            if ($reading->{"pm25_ch{$i}"} !== null) {
-                $sensors[] = "PM2.5 #{$i}";
-            }
-        }
-        
-        // CO2
-        if ($reading->co2 !== null) $sensors[] = 'CO2 sensor';
-
-        return $sensors;
+        return app(SensorTrackerService::class)->getCachedSensorStates($trackDays, $failMinutes);
     }
 
     /**

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -1403,6 +1403,11 @@ class SettingsController extends Controller
             'source_file_stale' => Setting::getValue('notifications.source_file_stale', true),
             'cache_missing' => Setting::getValue('notifications.cache_missing', false),
             'api_error' => Setting::getValue('notifications.api_error', false),
+
+            // Per-sensor health tracking (drives the "sensor offline" alerts)
+            'sensor_health_enabled' => Setting::getValue('sensor_health.enabled', true),
+            'sensor_health_fail_minutes' => (int) Setting::getValue('sensor_health.fail_minutes', 30),
+            'sensor_health_track_days' => (int) Setting::getValue('sensor_health.track_days', 7),
         ];
 
         return view('admin.settings.notifications', [
@@ -1439,6 +1444,16 @@ class SettingsController extends Controller
         Setting::setValue('notifications.source_file_stale', $sourceFileStale, 'boolean', 'notifications');
         Setting::setValue('notifications.cache_missing', $cacheMissing, 'boolean', 'notifications');
         Setting::setValue('notifications.api_error', $apiError, 'boolean', 'notifications');
+
+        // Per-sensor health tracking. Bounds match CheckSensorHealth so a value
+        // saved here can never disable detection by being out of range.
+        $sensorHealthEnabled = ($request->input('sensor_health_enabled') === '1');
+        $failMinutes = max(15, min(10080, (int) $request->input('sensor_health_fail_minutes', 30)));
+        $trackDays = max(1, min(30, (int) $request->input('sensor_health_track_days', 7)));
+
+        Setting::setValue('sensor_health.enabled', $sensorHealthEnabled, 'boolean', 'sensors');
+        Setting::setValue('sensor_health.fail_minutes', $failMinutes, 'integer', 'sensors');
+        Setting::setValue('sensor_health.track_days', $trackDays, 'integer', 'sensors');
 
         $this->clearSettingsCache();
 

--- a/app/Services/Notifications/NotificationDispatcher.php
+++ b/app/Services/Notifications/NotificationDispatcher.php
@@ -117,7 +117,8 @@ class NotificationDispatcher
                 ],
                 CURLOPT_RETURNTRANSFER => true,
                 CURLOPT_TIMEOUT => 10,
-                CURLOPT_SSL_VERIFYPEER => false,
+                CURLOPT_SSL_VERIFYPEER => true,
+                CURLOPT_SSL_VERIFYHOST => 2,
             ]);
 
             $response = curl_exec($ch);

--- a/app/Services/Notifications/NotificationDispatcher.php
+++ b/app/Services/Notifications/NotificationDispatcher.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Services\Notifications;
+
+use App\Models\Setting;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Single delivery path for operational alerts (email and/or webhook), driven by
+ * the notifications.* settings that Admin → Settings → Notifications writes.
+ *
+ * Every producer of operational alerts should go through here, so that a
+ * recipient configured once in the admin panel applies to all of them.
+ */
+class NotificationDispatcher
+{
+    /**
+     * Returns true when the alert was delivered by at least one channel.
+     * A false return is a normal outcome (disabled, unconfigured, rate limited)
+     * and is always logged.
+     */
+    public function send(string $subject, array $details = [], ?string $type = null): bool
+    {
+        if (!Setting::getValue('notifications.enabled', false)) {
+            Log::warning("Alert (notifications disabled): {$subject}", $details);
+            return false;
+        }
+
+        if ($type && !Setting::getValue("notifications.{$type}", true)) {
+            Log::info("Alert suppressed (type disabled): {$subject}", $details);
+            return false;
+        }
+
+        $method = Setting::getValue('notifications.method', 'email');
+        $email = (string) Setting::getValue('notifications.email', '');
+        $webhookUrl = (string) Setting::getValue('notifications.webhook_url', '');
+
+        $sendEmail = in_array($method, ['email', 'both'], true) && $email !== '';
+        $sendWebhook = in_array($method, ['webhook', 'both'], true) && $webhookUrl !== '';
+
+        if (!$sendEmail && !$sendWebhook) {
+            Log::warning("Alert (no notification method configured): {$subject}", $details);
+            return false;
+        }
+
+        $alertKey = 'alert_' . md5($subject . serialize($details));
+        $lastAlert = Cache::get($alertKey);
+        if ($lastAlert && $lastAlert->diffInMinutes(now()) < 60) {
+            Log::info("Alert suppressed (rate limit): {$subject}", $details);
+            return false;
+        }
+
+        $success = false;
+
+        if ($sendEmail) {
+            $success = $this->sendEmail($subject, $details, $email) || $success;
+        }
+
+        if ($sendWebhook) {
+            $success = $this->sendWebhook($subject, $details, $type, $webhookUrl) || $success;
+        }
+
+        if ($success) {
+            Cache::put($alertKey, now(), now()->addHours(1));
+        }
+
+        return $success;
+    }
+
+    private function sendEmail(string $subject, array $details, string $email): bool
+    {
+        try {
+            $body = "Weather Station Alert: {$subject}\n\n";
+            if ($details !== []) {
+                $body .= "Details:\n";
+                foreach ($details as $key => $value) {
+                    $body .= "  {$key}: " . (is_array($value) ? json_encode($value) : $value) . "\n";
+                }
+            }
+            $body .= "\nTime: " . now()->toDateTimeString() . "\n";
+
+            Mail::raw($body, function ($mail) use ($email, $subject) {
+                $mail->to($email)->subject("[WeatherNode] {$subject}");
+            });
+
+            Log::info("Alert email sent: {$subject}", ['email' => $email, 'details' => $details]);
+            return true;
+        } catch (\Exception $e) {
+            Log::error('Failed to send alert email', [
+                'error' => $e->getMessage(),
+                'subject' => $subject,
+                'email' => $email,
+            ]);
+            return false;
+        }
+    }
+
+    private function sendWebhook(string $subject, array $details, ?string $type, string $webhookUrl): bool
+    {
+        try {
+            $payload = [
+                'subject' => $subject,
+                'details' => $details,
+                'timestamp' => now()->toIso8601String(),
+                'alert_type' => $type,
+            ];
+
+            $ch = curl_init($webhookUrl);
+            curl_setopt_array($ch, [
+                CURLOPT_POST => true,
+                CURLOPT_POSTFIELDS => json_encode($payload),
+                CURLOPT_HTTPHEADER => [
+                    'Content-Type: application/json',
+                    'User-Agent: WeatherNode/1.0',
+                ],
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_TIMEOUT => 10,
+                CURLOPT_SSL_VERIFYPEER => false,
+            ]);
+
+            $response = curl_exec($ch);
+            $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $error = curl_error($ch);
+            curl_close($ch);
+
+            if ($httpCode >= 200 && $httpCode < 300) {
+                Log::info("Alert webhook sent: {$subject}", ['webhook' => $webhookUrl, 'details' => $details]);
+                return true;
+            }
+
+            Log::error('Webhook returned error', [
+                'http_code' => $httpCode,
+                'response' => $response,
+                'error' => $error,
+                'subject' => $subject,
+                'webhook' => $webhookUrl,
+            ]);
+            return false;
+        } catch (\Exception $e) {
+            Log::error('Failed to send webhook', [
+                'error' => $e->getMessage(),
+                'subject' => $subject,
+                'webhook' => $webhookUrl,
+            ]);
+            return false;
+        }
+    }
+}

--- a/app/Services/Weather/SensorTrackerService.php
+++ b/app/Services/Weather/SensorTrackerService.php
@@ -291,7 +291,19 @@ class SensorTrackerService
         if ($id === 'co2') {
             return __('CO2 sensor');
         }
-        // Battery keys: wh26batt, batt1, soilbatt1, etc.
+        // Battery keys: wh26batt, batt1, soilbatt1, pm25batt1, leakbatt1, leafbatt1, ...
+        if (preg_match('/^batt(\d+)$/', $id, $m)) {
+            return __('Battery sensor :n', ['n' => $m[1]]);
+        }
+        if (preg_match('/^(soil|pm25|leak|leaf)batt(\d+)$/', $id, $m)) {
+            $kinds = [
+                'soil' => 'Battery soil sensor :n',
+                'pm25' => 'Battery PM2.5 sensor :n',
+                'leak' => 'Battery leak sensor :n',
+                'leaf' => 'Battery leaf sensor :n',
+            ];
+            return __($kinds[$m[1]], ['n' => $m[2]]);
+        }
         if (str_ends_with($id, 'batt')) {
             return __('Battery :id', ['id' => $id]);
         }

--- a/app/Services/Weather/SensorTrackerService.php
+++ b/app/Services/Weather/SensorTrackerService.php
@@ -4,25 +4,68 @@ namespace App\Services\Weather;
 
 use App\Models\WeatherReading;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
 
 /**
  * Tracks which sensors have been active over a time window and detects
  * when one stops reporting (e.g. empty battery, lost contact).
- * Works with Ecowitt and other stations that store battery_status and
- * per-channel data (temp_1..8, soil_1..8, pm25_ch1..4, etc.).
+ *
+ * Detection works off the normalized WeatherReading columns, so it covers every
+ * source that writes readings (Ecowitt, WeatherLink, WeatherFlow, Ambient, Aeris,
+ * local files, ...). Ecowitt battery keys are tracked too where present, but they
+ * are not required: a station that goes quiet stops filling its columns, and that
+ * alone is enough to notice.
  */
 class SensorTrackerService
 {
     /**
-     * Sensor IDs we derive from each reading (data channels + battery keys).
-     * Used to build "active" set and "last seen" per sensor.
+     * Primary sensor ID => normalized columns that prove it reported.
+     * A sensor counts as present when at least one of its columns is non-null.
      */
-    public static function getSensorIdsFromReading(WeatherReading $reading): array
+    private const PRIMARY_SENSORS = [
+        'outdoor_temp_humidity' => ['temperature', 'humidity'],
+        'indoor_temp_humidity' => ['temperature_indoor', 'humidity_indoor', 'indoor_temperature', 'indoor_humidity'],
+        'barometer' => ['pressure_rel', 'pressure_abs'],
+        'wind' => ['wind_speed', 'wind_gust', 'wind_direction', 'wind_speed_avg_10m', 'wind_direction_avg_10m'],
+        'rain' => ['rain_rate', 'rain_hourly', 'rain_daily', 'rain_weekly', 'rain_monthly', 'rain_yearly', 'rain_event', 'rain_total'],
+        'solar' => ['solar_radiation', 'lux'],
+        'uv' => ['uv_index'],
+        'water_temp' => ['water_temperature'],
+        'pm10' => ['pm10', 'pm10_avg_24h'],
+        'soil' => ['soil_temperature', 'soil_moisture'],
+    ];
+
+    /** Cache key holding the precomputed sensor states for the admin UI. */
+    public const STATES_CACHE_KEY = 'sensor_states';
+
+    /** Kept longer than the 5-minute refresh so a page load rarely recomputes. */
+    private const STATES_CACHE_MINUTES = 30;
+
+    /** Minutes of silence before a sensor is shown as stale (below the alert threshold). */
+    private const STALE_MINUTES = 15;
+
+    /**
+     * Sensor IDs we derive from each reading (data channels + battery keys).
+     * Accepts a model or a raw row, so callers can skip Eloquent hydration.
+     */
+    public static function getSensorIdsFromReading(object $reading): array
     {
         $ids = [];
 
+        foreach (self::PRIMARY_SENSORS as $sensorId => $columns) {
+            foreach ($columns as $column) {
+                if (($reading->{$column} ?? null) !== null) {
+                    $ids[] = $sensorId;
+                    break;
+                }
+            }
+        }
+
         // Battery-backed sensors (Ecowitt keys: wh26batt, batt1, soilbatt1, etc.)
-        $battery = $reading->battery_status;
+        $battery = $reading->battery_status ?? null;
+        if (is_string($battery)) {
+            $battery = json_decode($battery, true);
+        }
         if (is_array($battery)) {
             foreach (array_keys($battery) as $key) {
                 $ids[] = $key;
@@ -31,46 +74,53 @@ class SensorTrackerService
 
         // Extra temperature sensors (temp_1 .. temp_8)
         for ($i = 1; $i <= 8; $i++) {
-            if ($reading->{"temp_{$i}"} !== null) {
+            if (($reading->{"temp_{$i}"} ?? null) !== null) {
                 $ids[] = "temp_{$i}";
             }
         }
 
         // Extra humidity (humidity_1 .. humidity_8)
         for ($i = 1; $i <= 8; $i++) {
-            if ($reading->{"humidity_{$i}"} !== null) {
+            if (($reading->{"humidity_{$i}"} ?? null) !== null) {
                 $ids[] = "humidity_{$i}";
             }
         }
 
         // Soil channels (soil_1 .. soil_8) – present if moisture or temp reported
         for ($i = 1; $i <= 8; $i++) {
-            if ($reading->{"soil_moisture_{$i}"} !== null || $reading->{"soil_temp_{$i}"} !== null) {
+            if (($reading->{"soil_moisture_{$i}"} ?? null) !== null || ($reading->{"soil_temp_{$i}"} ?? null) !== null) {
                 $ids[] = "soil_{$i}";
             }
         }
 
         // PM2.5 channels
         for ($i = 1; $i <= 4; $i++) {
-            if ($reading->{"pm25_ch{$i}"} !== null) {
+            if (($reading->{"pm25_ch{$i}"} ?? null) !== null) {
                 $ids[] = "pm25_ch{$i}";
             }
         }
 
         // Leak channels
         for ($i = 1; $i <= 4; $i++) {
-            if ($reading->{"leak_ch{$i}"} !== null) {
+            if (($reading->{"leak_ch{$i}"} ?? null) !== null) {
                 $ids[] = "leak_{$i}";
             }
         }
 
+        // Leaf wetness channels
+        for ($i = 1; $i <= 8; $i++) {
+            if (($reading->{"leaf_wetness_{$i}"} ?? null) !== null) {
+                $ids[] = "leaf_{$i}";
+            }
+        }
+
         // Lightning
-        if ($reading->lightning_distance !== null || $reading->lightning_count_daily !== null) {
+        if (($reading->lightning_distance ?? null) !== null || ($reading->lightning_count_daily ?? null) !== null) {
             $ids[] = 'lightning';
         }
 
         // CO2
-        if ($reading->co2 !== null) {
+        if (($reading->co2 ?? null) !== null) {
             $ids[] = 'co2';
         }
 
@@ -78,55 +128,31 @@ class SensorTrackerService
     }
 
     /**
-     * Get all sensor IDs that have been seen in the last $trackDays days.
-     * Uses chunking to avoid loading all readings into memory.
+     * Latest recorded_at per sensor across the tracking window, in one pass.
+     *
+     * Rows are read as plain records rather than Eloquent models: this window is
+     * one row per minute, so hydration dominated the cost.
+     *
+     * @return array<string, Carbon>
      */
-    public function getActiveSensorIds(int $trackDays): array
+    public function getLastSeenForAllSensors(int $trackDays): array
     {
         $since = now()->subDays($trackDays);
-        $active = [];
+        $lastSeen = [];
 
-        WeatherReading::where('recorded_at', '>=', $since)
-            ->orderBy('recorded_at', 'desc')
-            ->chunk(500, function ($readings) use (&$active) {
-                foreach ($readings as $r) {
-                    foreach (self::getSensorIdsFromReading($r) as $id) {
-                        $active[$id] = true;
-                    }
-                }
-            });
-
-        return array_keys($active);
-    }
-
-    /**
-     * For each active sensor, get the latest recorded_at from readings that contain it.
-     * Returns array keyed by sensor_id => Carbon (last_seen).
-     * Uses chunking to avoid loading all readings into memory.
-     */
-    public function getLastSeenForSensors(array $sensorIds, int $withinDays): array
-    {
-        if (empty($sensorIds)) {
-            return [];
-        }
-
-        $since = now()->subDays($withinDays);
-        $lastSeen = array_fill_keys($sensorIds, null);
-
-        WeatherReading::where('recorded_at', '>=', $since)
+        WeatherReading::query()
+            ->toBase()
+            ->where('recorded_at', '>=', $since)
             ->orderBy('recorded_at', 'asc')
-            ->chunk(500, function ($readings) use (&$lastSeen) {
+            ->chunk(1000, function ($readings) use (&$lastSeen) {
                 foreach ($readings as $r) {
-                    $ids = self::getSensorIdsFromReading($r);
                     $at = $r->recorded_at instanceof \DateTimeInterface
                         ? Carbon::instance($r->recorded_at)
                         : Carbon::parse($r->recorded_at);
-                    foreach ($ids as $id) {
-                        if (isset($lastSeen[$id])) {
-                            if ($lastSeen[$id] === null || $at->isAfter($lastSeen[$id])) {
-                                $lastSeen[$id] = $at;
-                            }
-                        }
+
+                    // Ascending order, so a later row always wins.
+                    foreach (self::getSensorIdsFromReading($r) as $id) {
+                        $lastSeen[$id] = $at;
                     }
                 }
             });
@@ -140,19 +166,10 @@ class SensorTrackerService
      */
     public function getFailedSensors(int $trackDays, int $failMinutes): array
     {
-        $activeIds = $this->getActiveSensorIds($trackDays);
-        if (empty($activeIds)) {
-            return [];
-        }
-
-        $lastSeen = $this->getLastSeenForSensors($activeIds, $trackDays);
         $threshold = now()->subMinutes($failMinutes);
         $failed = [];
 
-        foreach ($lastSeen as $sensorId => $at) {
-            if ($at === null) {
-                continue;
-            }
+        foreach ($this->getLastSeenForAllSensors($trackDays) as $sensorId => $at) {
             if ($at->isBefore($threshold)) {
                 $failed[] = [
                     'id' => $sensorId,
@@ -165,10 +182,94 @@ class SensorTrackerService
     }
 
     /**
+     * Every known sensor with its current state: 'ok' when it reported recently,
+     * 'failed' once past the alert threshold, 'stale' in between. Failed first.
+     *
+     * @return array<int, array{id: string, label: string, state: string, last_seen: Carbon, minutes_ago: int}>
+     */
+    public function getSensorStates(int $trackDays, int $failMinutes): array
+    {
+        $states = [];
+
+        foreach ($this->getLastSeenForAllSensors($trackDays) as $sensorId => $at) {
+            $minutesAgo = (int) round(abs(now()->diffInMinutes($at)));
+
+            if ($minutesAgo >= $failMinutes) {
+                $state = 'failed';
+            } elseif ($minutesAgo >= self::STALE_MINUTES) {
+                $state = 'stale';
+            } else {
+                $state = 'ok';
+            }
+
+            $states[] = [
+                'id' => $sensorId,
+                'label' => self::sensorIdToLabel($sensorId),
+                'state' => $state,
+                'last_seen' => $at,
+                'minutes_ago' => $minutesAgo,
+            ];
+        }
+
+        usort($states, function ($a, $b) {
+            $rank = ['failed' => 0, 'stale' => 1, 'ok' => 2];
+
+            return [$rank[$a['state']], $a['label']] <=> [$rank[$b['state']], $b['label']];
+        });
+
+        return $states;
+    }
+
+    /**
+     * Recompute and store the states. Called from the scheduled health check so
+     * that page loads never pay for the scan.
+     */
+    public function refreshSensorStates(int $trackDays, int $failMinutes): array
+    {
+        $states = $this->getSensorStates($trackDays, $failMinutes);
+        Cache::put(self::STATES_CACHE_KEY, $states, now()->addMinutes(self::STATES_CACHE_MINUTES));
+
+        return $states;
+    }
+
+    /**
+     * States for display. Falls back to computing them once if the scheduler
+     * has not run recently, rather than showing nothing.
+     */
+    public function getCachedSensorStates(int $trackDays, int $failMinutes): array
+    {
+        $cached = Cache::get(self::STATES_CACHE_KEY);
+        if (is_array($cached)) {
+            return $cached;
+        }
+
+        return $this->refreshSensorStates($trackDays, $failMinutes);
+    }
+
+    /**
      * Human-friendly label for a sensor ID (for alerts and UI).
      */
     public static function sensorIdToLabel(string $id): string
     {
+        $primary = [
+            'outdoor_temp_humidity' => 'Outdoor temp/humidity',
+            'indoor_temp_humidity' => 'Indoor temp/humidity',
+            'barometer' => 'Barometer',
+            'wind' => 'Wind sensor',
+            'rain' => 'Rain gauge',
+            'solar' => 'Solar sensor',
+            'uv' => 'UV sensor',
+            'water_temp' => 'Water temperature',
+            'pm10' => 'PM10 sensor',
+            'soil' => 'Soil sensor',
+        ];
+        if (isset($primary[$id])) {
+            return __($primary[$id]);
+        }
+
+        if (preg_match('/^leaf_(\d+)$/', $id, $m)) {
+            return __('Leaf wetness :n', ['n' => $m[1]]);
+        }
         if (preg_match('/^temp_(\d+)$/', $id, $m)) {
             return __('Extra temp :n', ['n' => $m[1]]);
         }

--- a/database/migrations/2026_08_17_090000_add_sensor_health_settings.php
+++ b/database/migrations/2026_08_17_090000_add_sensor_health_settings.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Per-sensor health tracking gained an admin control. Upgrades only run
+ * migrations, never the seeder, so the settings have to arrive here.
+ */
+return new class extends Migration
+{
+    private const SETTINGS = [
+        ['key' => 'sensor_health.enabled', 'value' => '1', 'type' => 'boolean', 'group' => 'sensors', 'description' => 'Track individual sensors over time and alert when one stops reporting (e.g. empty battery)'],
+        ['key' => 'sensor_health.track_days', 'value' => '7', 'type' => 'integer', 'group' => 'sensors', 'description' => 'Consider a sensor "active" if it reported in the last N days'],
+        ['key' => 'sensor_health.fail_minutes', 'value' => '30', 'type' => 'integer', 'group' => 'sensors', 'description' => 'Alert if an active sensor has not reported in this many minutes'],
+    ];
+
+    private const OLD_DEFAULT_FAIL_MINUTES = '120';
+
+    public function up(): void
+    {
+        foreach (self::SETTINGS as $setting) {
+            DB::table('settings')->insertOrIgnore(array_merge($setting, [
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]));
+        }
+
+        // 120 shipped as the default while the value was unreachable from the
+        // admin panel, so it reflects no decision. Anything else is left alone.
+        DB::table('settings')
+            ->where('key', 'sensor_health.fail_minutes')
+            ->where('value', self::OLD_DEFAULT_FAIL_MINUTES)
+            ->update(['value' => '30', 'updated_at' => now()]);
+    }
+
+    public function down(): void
+    {
+        DB::table('settings')
+            ->where('key', 'sensor_health.fail_minutes')
+            ->where('value', '30')
+            ->update(['value' => self::OLD_DEFAULT_FAIL_MINUTES, 'updated_at' => now()]);
+    }
+};

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -171,7 +171,7 @@ class SettingsSeeder extends Seeder
             // ===== Sensor health tracking (individual sensors: fail alert if one stops reporting) =====
             ['key' => 'sensor_health.enabled', 'value' => '1', 'type' => 'boolean', 'group' => 'sensors', 'description' => 'Track individual sensors over time and alert when one stops reporting (e.g. empty battery)'],
             ['key' => 'sensor_health.track_days', 'value' => '7', 'type' => 'integer', 'group' => 'sensors', 'description' => 'Consider a sensor "active" if it reported in the last N days'],
-            ['key' => 'sensor_health.fail_minutes', 'value' => '120', 'type' => 'integer', 'group' => 'sensors', 'description' => 'Alert if an active sensor has not reported in this many minutes'],
+            ['key' => 'sensor_health.fail_minutes', 'value' => '30', 'type' => 'integer', 'group' => 'sensors', 'description' => 'Alert if an active sensor has not reported in this many minutes'],
 
             // ===== Lightning =====
             ['key' => 'lightning.enabled', 'value' => '1', 'type' => 'boolean', 'group' => 'lightning', 'description' => 'Show lightning data (from station sensor)'],

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -235,19 +235,46 @@
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-6 mb-6 md:mb-8">
     <!-- Active Sensors -->
     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-4 md:p-6">
+        @php
+            $failedSensors = collect($sensorStates)->where('state', 'failed');
+            $staleSensors = collect($sensorStates)->where('state', 'stale');
+        @endphp
+
         <div class="flex items-center justify-between mb-4">
-            <h2 class="text-base md:text-lg font-semibold text-gray-900 dark:text-white">📡 {{ __('Active Sensors') }}</h2>
-            <span class="px-2 py-0.5 md:py-1 text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 rounded-full">
-                {{ count($activeSensors) }} {{ __('active') }}
-            </span>
+            <h2 class="text-base md:text-lg font-semibold text-gray-900 dark:text-white">📡 {{ __('Sensors') }}</h2>
+            @if($failedSensors->isNotEmpty())
+                <span class="px-2 py-0.5 md:py-1 text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400 rounded-full">
+                    {{ $failedSensors->count() }} {{ __('not reporting') }}
+                </span>
+            @else
+                <span class="px-2 py-0.5 md:py-1 text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 rounded-full">
+                    {{ count($sensorStates) }} {{ __('reporting') }}
+                </span>
+            @endif
         </div>
-        
-        @if(count($activeSensors) > 0)
+
+        @if(count($sensorStates) > 0)
+            @if($failedSensors->isNotEmpty())
+                <p class="mb-3 text-xs text-red-700 dark:text-red-400">
+                    {{ __('These sensors were reporting recently but have gone quiet. Check power, batteries or radio contact.') }}
+                </p>
+            @endif
             <div class="flex flex-wrap gap-1.5 md:gap-2">
-                @foreach($activeSensors as $sensor)
-                    <span class="inline-flex items-center px-2 py-1 md:px-3 md:py-1.5 rounded-full text-xs md:text-sm font-medium bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
-                        <span class="w-1.5 h-1.5 md:w-2 md:h-2 rounded-full bg-green-500 mr-1.5 md:mr-2"></span>
-                        {{ $sensor }}
+                @foreach($sensorStates as $sensor)
+                    @php
+                        $chip = match($sensor['state']) {
+                            'failed' => ['bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300', 'bg-red-500'],
+                            'stale' => ['bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300', 'bg-amber-500'],
+                            default => ['bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300', 'bg-green-500'],
+                        };
+                    @endphp
+                    <span class="inline-flex items-center px-2 py-1 md:px-3 md:py-1.5 rounded-full text-xs md:text-sm font-medium {{ $chip[0] }}"
+                          @if($sensor['last_seen']) title="{{ __('Last seen') }}: {{ $sensor['last_seen']->format('Y-m-d H:i') }}" @endif>
+                        <span class="w-1.5 h-1.5 md:w-2 md:h-2 rounded-full {{ $chip[1] }} mr-1.5 md:mr-2"></span>
+                        {{ $sensor['label'] }}
+                        @if($sensor['state'] !== 'ok' && $sensor['minutes_ago'] !== null)
+                            <span class="ml-1.5 opacity-75">{{ $sensor['last_seen']->diffForHumans() }}</span>
+                        @endif
                     </span>
                 @endforeach
             </div>

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -271,9 +271,10 @@
                     <span class="inline-flex items-center px-2 py-1 md:px-3 md:py-1.5 rounded-full text-xs md:text-sm font-medium {{ $chip[0] }}"
                           @if($sensor['last_seen']) title="{{ __('Last seen') }}: {{ $sensor['last_seen']->format('Y-m-d H:i') }}" @endif>
                         <span class="w-1.5 h-1.5 md:w-2 md:h-2 rounded-full {{ $chip[1] }} mr-1.5 md:mr-2"></span>
-                        {{ $sensor['label'] }}
+                        <span>{{ $sensor['label'] }}</span>
                         @if($sensor['state'] !== 'ok' && $sensor['minutes_ago'] !== null)
-                            <span class="ml-1.5 opacity-75">{{ $sensor['last_seen']->diffForHumans() }}</span>
+                            <span class="mx-1.5 opacity-50" aria-hidden="true">&middot;</span>
+                            <span class="opacity-75 whitespace-nowrap">{{ $sensor['last_seen']->diffForHumans() }}</span>
                         @endif
                     </span>
                 @endforeach

--- a/resources/views/admin/help.blade.php
+++ b/resources/views/admin/help.blade.php
@@ -400,9 +400,9 @@ UPDATER_NOTIFY_EMAIL=true
             <div class="border border-gray-200 dark:border-gray-700 rounded-lg p-4 mb-4">
                 <h3 class="font-semibold text-gray-800 dark:text-white mb-3">{{ __('Configure Email Alerts') }}</h3>
                 <ol class="text-sm text-gray-600 dark:text-gray-400 space-y-2 list-decimal list-inside">
-                    <li>{{ __('Go to') }} <a href="{{ route('admin.settings.index') }}" class="text-blue-600 hover:underline">{{ __('Settings') }}</a></li>
-                    <li>{{ __('Add setting') }} <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded">alerts.enabled</code> = <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded">true</code></li>
-                    <li>{{ __('Add setting') }} <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded">alerts.email</code> = <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded">your-email@example.com</code></li>
+                    <li>{{ __('Go to') }} <a href="{{ route('admin.settings.notifications') }}" class="text-blue-600 hover:underline">{{ __('Admin → Settings → Notifications') }}</a></li>
+                    <li>{{ __('Turn on') }} <strong>{{ __('Enable Notifications') }}</strong>, {{ __('pick a method and enter the email address that should receive alerts') }}</li>
+                    <li>{{ __('Keep') }} <strong>{{ __('Sensor Offline') }}</strong> {{ __('enabled, and set the thresholds under') }} <strong>{{ __('Individual Sensor Tracking') }}</strong></li>
                     <li>{{ __('Configure mail provider in') }} <a href="{{ route('admin.settings.mail') }}" class="text-blue-600 hover:underline">{{ __('Admin → Settings → Mail') }}</a>:
                         <ul class="ml-6 mt-2 space-y-1 list-disc">
                             <li><strong>{{ __('OAuth2 (Recommended)') }}:</strong> {{ __('For Gmail and Microsoft/Office 365. Enter Client ID and Client Secret, then click "Authorize" to complete OAuth flow. Token refresh is automatic.') }}</li>

--- a/resources/views/admin/settings/notifications.blade.php
+++ b/resources/views/admin/settings/notifications.blade.php
@@ -195,6 +195,44 @@
             </div>
         </div>
 
+        <!-- Per-sensor health tracking -->
+        <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm">
+            <div class="p-5 space-y-4">
+                <div>
+                    <label class="block text-sm font-medium text-gray-900 dark:text-white">{{ __('Individual Sensor Tracking') }}</label>
+                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ __('Detect a single sensor going quiet (flat battery, lost contact) even while the station keeps sending other data.') }}</p>
+                </div>
+
+                <div class="flex items-center justify-between py-2 border-t border-gray-100 dark:border-gray-700">
+                    <div>
+                        <label class="text-sm font-medium text-gray-900 dark:text-white">{{ __('Track Individual Sensors') }}</label>
+                        <p class="text-xs text-gray-500 dark:text-gray-400">{{ __('Uses the "Sensor Offline" notification type above') }}</p>
+                    </div>
+                    <x-toggle-switch
+                        :enabled="($settings['sensor_health_enabled'] ?? true)"
+                        name="sensor_health_enabled"
+                    />
+                </div>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-2 border-t border-gray-100 dark:border-gray-700">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-900 dark:text-white mb-2">{{ __('Alert After (minutes)') }}</label>
+                        <input type="number" name="sensor_health_fail_minutes" min="15" max="10080" step="1"
+                            value="{{ old('sensor_health_fail_minutes', $settings['sensor_health_fail_minutes'] ?? 30) }}"
+                            class="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ __('How long a known sensor may stay silent before an alert is sent (15–10080).') }}</p>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-900 dark:text-white mb-2">{{ __('Remember Sensors For (days)') }}</label>
+                        <input type="number" name="sensor_health_track_days" min="1" max="30" step="1"
+                            value="{{ old('sensor_health_track_days', $settings['sensor_health_track_days'] ?? 7) }}"
+                            class="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ __('A sensor seen within this window is expected to keep reporting (1–30).') }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Info Box -->
         <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-xl p-4">
             <div class="flex items-start">

--- a/tests/Feature/Admin/DashboardSensorStateTest.php
+++ b/tests/Feature/Admin/DashboardSensorStateTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Setting;
+use App\Models\User;
+use App\Models\WeatherReading;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DashboardSensorStateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function adminUser(): User
+    {
+        return User::factory()->create(['is_admin' => true]);
+    }
+
+    /**
+     * A sensor that has gone quiet must stay visible with a failed state
+     * instead of silently disappearing from the list.
+     */
+    public function test_shows_a_silent_sensor_as_failed_instead_of_dropping_it(): void
+    {
+        Setting::setValue('sensor_health.fail_minutes', '30', 'integer', 'sensor_health');
+
+        WeatherReading::create([
+            'recorded_at' => now()->subHours(4),
+            'temperature' => 17.2,
+            'wind_speed' => 9.0,
+        ]);
+        WeatherReading::create([
+            'recorded_at' => now()->subMinute(),
+            'temperature' => 18.1,
+        ]);
+
+        $response = $this->actingAs($this->adminUser())->get(route('admin.dashboard'));
+
+        $response->assertOk();
+        $response->assertSee('Wind sensor');
+        $response->assertSee('Outdoor temp/humidity');
+        $response->assertViewHas('sensorStates', function (array $states) {
+            $byId = collect($states)->keyBy('id');
+
+            return $byId['wind']['state'] === 'failed'
+                && $byId['outdoor_temp_humidity']['state'] === 'ok';
+        });
+    }
+
+    public function test_reports_every_sensor_ok_while_all_are_reporting(): void
+    {
+        Setting::setValue('sensor_health.fail_minutes', '30', 'integer', 'sensor_health');
+
+        WeatherReading::create([
+            'recorded_at' => now()->subMinute(),
+            'temperature' => 18.1,
+            'wind_speed' => 11.0,
+        ]);
+
+        $response = $this->actingAs($this->adminUser())->get(route('admin.dashboard'));
+
+        $response->assertOk();
+        $response->assertViewHas('sensorStates', function (array $states) {
+            return collect($states)->every(fn ($s) => $s['state'] === 'ok');
+        });
+    }
+}

--- a/tests/Feature/Admin/SensorHealthSettingsTest.php
+++ b/tests/Feature/Admin/SensorHealthSettingsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SensorHealthSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function adminUser(): User
+    {
+        return User::factory()->create(['is_admin' => true]);
+    }
+
+    public function test_notifications_page_exposes_sensor_health_controls(): void
+    {
+        $response = $this->actingAs($this->adminUser())
+            ->get(route('admin.settings.notifications'));
+
+        $response->assertOk();
+        $response->assertSee('sensor_health_enabled', false);
+        $response->assertSee('sensor_health_fail_minutes', false);
+        $response->assertSee('sensor_health_track_days', false);
+    }
+
+    public function test_saves_sensor_health_thresholds(): void
+    {
+        $this->actingAs($this->adminUser())
+            ->post(route('admin.settings.notifications.update'), [
+                'notifications_enabled' => '1',
+                'method' => 'email',
+                'email' => 'ops@example.com',
+                'sensor_health_enabled' => '1',
+                'sensor_health_fail_minutes' => '45',
+                'sensor_health_track_days' => '10',
+            ])
+            ->assertRedirect(route('admin.settings.notifications'));
+
+        $this->assertSame('45', (string) Setting::getValue('sensor_health.fail_minutes'));
+        $this->assertSame('10', (string) Setting::getValue('sensor_health.track_days'));
+    }
+
+    public function test_clamps_out_of_range_thresholds(): void
+    {
+        $this->actingAs($this->adminUser())
+            ->post(route('admin.settings.notifications.update'), [
+                'notifications_enabled' => '1',
+                'method' => 'email',
+                'email' => 'ops@example.com',
+                'sensor_health_enabled' => '1',
+                'sensor_health_fail_minutes' => '2',
+                'sensor_health_track_days' => '999',
+            ]);
+
+        $this->assertSame(15, (int) Setting::getValue('sensor_health.fail_minutes'));
+        $this->assertSame(30, (int) Setting::getValue('sensor_health.track_days'));
+    }
+}

--- a/tests/Unit/Console/CheckSensorHealthCommandTest.php
+++ b/tests/Unit/Console/CheckSensorHealthCommandTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console;
+
+use App\Models\Setting;
+use App\Models\WeatherReading;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class CheckSensorHealthCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Setting::setValue('notifications.enabled', '1', 'boolean', 'notifications');
+        Setting::setValue('notifications.method', 'email', 'select', 'notifications');
+        Setting::setValue('notifications.email', 'ops@example.com', 'string', 'notifications');
+        Setting::setValue('sensor_health.fail_minutes', '30', 'integer', 'sensor_health');
+    }
+
+    /** Decoded so quoted-printable soft line breaks don't split the sensor labels. */
+    private function sentBodies(): array
+    {
+        return Mail::mailer()->getSymfonyTransport()->messages()
+            ->map(fn ($message) => quoted_printable_decode($message->getOriginalMessage()->toString()))
+            ->all();
+    }
+
+    private function assertMailSentContaining(string $needle): void
+    {
+        foreach ($this->sentBodies() as $body) {
+            if (str_contains($body, $needle)) {
+                $this->assertTrue(true);
+                return;
+            }
+        }
+
+        $this->fail("No notification containing \"{$needle}\" was sent.");
+    }
+
+    private function assertNoMailSentContaining(string $needle): void
+    {
+        foreach ($this->sentBodies() as $body) {
+            if (str_contains($body, $needle)) {
+                $this->fail("Unexpected notification containing \"{$needle}\" was sent.");
+            }
+        }
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * The station keeps publishing indoor values while the outdoor array is
+     * silent — the failure mode that produced no alert on 2026-08-15.
+     */
+    public function test_alerts_when_outdoor_sensors_stop_while_station_keeps_reporting(): void
+    {
+        WeatherReading::create([
+            'recorded_at' => now()->subHours(4),
+            'temperature' => 17.2,
+            'humidity' => 68,
+            'wind_speed' => 9.0,
+            'rain_daily' => 0.2,
+            'temperature_indoor' => 26.0,
+        ]);
+        WeatherReading::create([
+            'recorded_at' => now()->subMinute(),
+            'temperature_indoor' => 26.9,
+            'humidity_indoor' => 61,
+        ]);
+
+        $this->artisan('weather:check-sensor-health')->assertExitCode(0);
+
+        $this->assertMailSentContaining('Outdoor temp/humidity');
+        $this->assertMailSentContaining('Wind sensor');
+    }
+
+    public function test_does_not_alert_while_every_sensor_is_still_reporting(): void
+    {
+        WeatherReading::create([
+            'recorded_at' => now()->subHours(4),
+            'temperature' => 17.2,
+            'wind_speed' => 9.0,
+        ]);
+        WeatherReading::create([
+            'recorded_at' => now()->subMinute(),
+            'temperature' => 18.1,
+            'wind_speed' => 11.0,
+        ]);
+
+        $this->artisan('weather:check-sensor-health')->assertExitCode(0);
+
+        $this->assertNoMailSentContaining('stopped reporting');
+    }
+
+    public function test_sends_recovery_notice_once_sensors_report_again(): void
+    {
+        WeatherReading::create([
+            'recorded_at' => now()->subHours(4),
+            'temperature' => 17.2,
+            'wind_speed' => 9.0,
+        ]);
+        WeatherReading::create([
+            'recorded_at' => now()->subMinute(),
+            'temperature_indoor' => 26.9,
+        ]);
+
+        $this->artisan('weather:check-sensor-health')->assertExitCode(0);
+        $this->assertMailSentContaining('Wind sensor');
+
+        WeatherReading::create([
+            'recorded_at' => now(),
+            'temperature' => 18.4,
+            'wind_speed' => 10.0,
+        ]);
+
+        $this->artisan('weather:check-sensor-health')->assertExitCode(0);
+
+        $this->assertMailSentContaining('reporting again');
+    }
+
+    public function test_honours_the_configured_failure_threshold(): void
+    {
+        Setting::setValue('sensor_health.fail_minutes', '360', 'integer', 'sensor_health');
+
+        WeatherReading::create([
+            'recorded_at' => now()->subHours(4),
+            'temperature' => 17.2,
+            'wind_speed' => 9.0,
+        ]);
+        WeatherReading::create([
+            'recorded_at' => now()->subMinute(),
+            'temperature_indoor' => 26.9,
+        ]);
+
+        $this->artisan('weather:check-sensor-health')->assertExitCode(0);
+
+        $this->assertNoMailSentContaining('Wind sensor');
+    }
+}

--- a/tests/Unit/Console/CheckSensorHealthCommandTest.php
+++ b/tests/Unit/Console/CheckSensorHealthCommandTest.php
@@ -125,6 +125,60 @@ class CheckSensorHealthCommandTest extends TestCase
         $this->assertMailSentContaining('reporting again');
     }
 
+    /**
+     * The "already alerted" flag used to be set even when delivery failed, so a
+     * failure detected before notifications were configured silenced the alert
+     * for 24 hours after they were.
+     */
+    public function test_retries_the_alert_after_a_failed_delivery(): void
+    {
+        Setting::setValue('notifications.enabled', '0', 'boolean', 'notifications');
+
+        WeatherReading::create([
+            'recorded_at' => now()->subHours(4),
+            'temperature' => 17.2,
+            'wind_speed' => 9.0,
+        ]);
+        WeatherReading::create([
+            'recorded_at' => now()->subMinute(),
+            'temperature' => 18.1,
+        ]);
+
+        $this->artisan('weather:check-sensor-health')->assertExitCode(0);
+        $this->assertNoMailSentContaining('Wind sensor');
+
+        Setting::setValue('notifications.enabled', '1', 'boolean', 'notifications');
+
+        $this->artisan('weather:check-sensor-health')->assertExitCode(0);
+
+        $this->assertMailSentContaining('Wind sensor');
+    }
+
+    public function test_alerts_again_when_a_further_sensor_stops(): void
+    {
+        WeatherReading::create([
+            'recorded_at' => now()->subHours(4),
+            'temperature' => 17.2,
+            'wind_speed' => 9.0,
+        ]);
+        WeatherReading::create([
+            'recorded_at' => now()->subMinutes(10),
+            'temperature' => 18.1,
+            'rain_daily' => 0.4,
+        ]);
+
+        $this->artisan('weather:check-sensor-health')->assertExitCode(0);
+        $this->assertMailSentContaining('Wind sensor');
+        $this->assertNoMailSentContaining('Rain gauge');
+
+        // The rain gauge now falls past the threshold too.
+        $this->travel(35)->minutes();
+
+        $this->artisan('weather:check-sensor-health')->assertExitCode(0);
+
+        $this->assertMailSentContaining('Rain gauge');
+    }
+
     public function test_honours_the_configured_failure_threshold(): void
     {
         Setting::setValue('sensor_health.fail_minutes', '360', 'integer', 'sensor_health');

--- a/tests/Unit/Migrations/AddSensorHealthSettingsMigrationTest.php
+++ b/tests/Unit/Migrations/AddSensorHealthSettingsMigrationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AddSensorHealthSettingsMigrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const KEYS = [
+        'sensor_health.enabled',
+        'sensor_health.track_days',
+        'sensor_health.fail_minutes',
+    ];
+
+    private function clearKeys(): void
+    {
+        DB::table('settings')->whereIn('key', self::KEYS)->delete();
+    }
+
+    public function test_up_creates_the_settings_when_missing(): void
+    {
+        $this->clearKeys();
+
+        $this->migration()->up();
+
+        $this->assertDatabaseHas('settings', ['key' => 'sensor_health.enabled', 'value' => '1']);
+        $this->assertDatabaseHas('settings', ['key' => 'sensor_health.track_days', 'value' => '7']);
+        $this->assertDatabaseHas('settings', ['key' => 'sensor_health.fail_minutes', 'value' => '30']);
+    }
+
+    /**
+     * 120 was the shipped default while no admin control existed, so it is a
+     * stale default rather than a choice anyone made.
+     */
+    public function test_up_lowers_the_untouched_two_hour_default(): void
+    {
+        $this->clearKeys();
+        DB::table('settings')->insert([
+            'key' => 'sensor_health.fail_minutes',
+            'value' => '120',
+            'type' => 'integer',
+            'group' => 'sensors',
+            'description' => 'Alert if an active sensor has not reported in this many minutes',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->migration()->up();
+
+        $this->assertDatabaseHas('settings', ['key' => 'sensor_health.fail_minutes', 'value' => '30']);
+    }
+
+    public function test_up_leaves_a_deliberately_chosen_threshold_alone(): void
+    {
+        $this->clearKeys();
+        DB::table('settings')->insert([
+            'key' => 'sensor_health.fail_minutes',
+            'value' => '240',
+            'type' => 'integer',
+            'group' => 'sensors',
+            'description' => 'Alert if an active sensor has not reported in this many minutes',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->migration()->up();
+
+        $this->assertDatabaseHas('settings', ['key' => 'sensor_health.fail_minutes', 'value' => '240']);
+    }
+
+    public function test_up_does_not_overwrite_an_existing_enabled_choice(): void
+    {
+        $this->clearKeys();
+        DB::table('settings')->insert([
+            'key' => 'sensor_health.enabled',
+            'value' => '0',
+            'type' => 'boolean',
+            'group' => 'sensors',
+            'description' => 'Track individual sensors',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->migration()->up();
+
+        $this->assertDatabaseHas('settings', ['key' => 'sensor_health.enabled', 'value' => '0']);
+    }
+
+    private function migration(): Migration
+    {
+        return require database_path('migrations/2026_08_17_090000_add_sensor_health_settings.php');
+    }
+}

--- a/tests/Unit/Services/Notifications/NotificationDispatcherTest.php
+++ b/tests/Unit/Services/Notifications/NotificationDispatcherTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Notifications;
+
+use App\Models\Setting;
+use App\Services\Notifications\NotificationDispatcher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class NotificationDispatcherTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** Messages captured by the array mail transport configured in phpunit.xml. */
+    private function sentCount(): int
+    {
+        return Mail::mailer()->getSymfonyTransport()->messages()->count();
+    }
+
+    private function configureEmail(string $address = 'ops@example.com'): void
+    {
+        Setting::setValue('notifications.enabled', '1', 'boolean', 'notifications');
+        Setting::setValue('notifications.method', 'email', 'select', 'notifications');
+        Setting::setValue('notifications.email', $address, 'string', 'notifications');
+    }
+
+    public function test_sends_email_when_notifications_are_configured(): void
+    {
+        $this->configureEmail();
+
+        $sent = app(NotificationDispatcher::class)->send('Sensor stopped reporting', ['sensor' => 'wind']);
+
+        $this->assertTrue($sent);
+        $this->assertSame(1, $this->sentCount());
+    }
+
+    public function test_does_not_send_when_notifications_are_disabled(): void
+    {
+        $this->configureEmail();
+        Setting::setValue('notifications.enabled', '0', 'boolean', 'notifications');
+
+        $sent = app(NotificationDispatcher::class)->send('Sensor stopped reporting', []);
+
+        $this->assertFalse($sent);
+        $this->assertSame(0, $this->sentCount());
+    }
+
+    public function test_does_not_send_when_no_recipient_is_configured(): void
+    {
+        $this->configureEmail('');
+
+        $sent = app(NotificationDispatcher::class)->send('Sensor stopped reporting', []);
+
+        $this->assertFalse($sent);
+        $this->assertSame(0, $this->sentCount());
+    }
+
+    public function test_respects_per_type_toggle(): void
+    {
+        $this->configureEmail();
+        Setting::setValue('notifications.sensor_offline', '0', 'boolean', 'notifications');
+
+        $sent = app(NotificationDispatcher::class)->send('Sensor stopped reporting', [], 'sensor_offline');
+
+        $this->assertFalse($sent);
+        $this->assertSame(0, $this->sentCount());
+    }
+
+    public function test_rate_limits_repeat_alerts_for_the_same_key(): void
+    {
+        $this->configureEmail();
+        $dispatcher = app(NotificationDispatcher::class);
+
+        $this->assertTrue($dispatcher->send('Sensor stopped reporting', ['sensor' => 'wind'], 'sensor_offline'));
+        $this->assertFalse($dispatcher->send('Sensor stopped reporting', ['sensor' => 'wind'], 'sensor_offline'));
+
+        $this->assertSame(1, $this->sentCount());
+    }
+
+    public function test_recovery_notice_is_not_blocked_by_the_failure_rate_limit(): void
+    {
+        $this->configureEmail();
+        $dispatcher = app(NotificationDispatcher::class);
+
+        $dispatcher->send('Sensor stopped reporting', ['sensor' => 'wind'], 'sensor_offline');
+        $sent = $dispatcher->send('Sensor reporting again', ['sensor' => 'wind'], 'sensor_offline');
+
+        $this->assertTrue($sent);
+        $this->assertSame(2, $this->sentCount());
+    }
+}

--- a/tests/Unit/Services/Weather/SensorTrackerServiceTest.php
+++ b/tests/Unit/Services/Weather/SensorTrackerServiceTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Weather;
+
+use App\Models\WeatherReading;
+use App\Services\Weather\SensorTrackerService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SensorTrackerServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * The reading window is large (a row per minute for days), so it must be
+     * walked once per computation, not once per helper.
+     */
+    public function test_scans_the_reading_window_only_once(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            WeatherReading::create([
+                'recorded_at' => now()->subMinutes(10 - $i),
+                'temperature' => 18.0,
+                'wind_speed' => 5.0,
+            ]);
+        }
+
+        DB::enableQueryLog();
+        (new SensorTrackerService())->getFailedSensors(7, 30);
+        $selects = collect(DB::getRawQueryLog())
+            ->filter(fn ($q) => str_contains($q['raw_query'], 'from "weather_readings"'))
+            ->count();
+        DB::disableQueryLog();
+
+        $this->assertSame(1, $selects);
+    }
+
+    public function test_states_report_ok_stale_and_failed(): void
+    {
+        WeatherReading::create([
+            'recorded_at' => now()->subHours(4),
+            'temperature' => 17.2,
+            'wind_speed' => 9.0,
+        ]);
+        WeatherReading::create([
+            'recorded_at' => now()->subMinutes(20),
+            'solar_radiation' => 120.0,
+        ]);
+        WeatherReading::create([
+            'recorded_at' => now()->subMinute(),
+            'temperature' => 18.1,
+        ]);
+
+        $states = collect((new SensorTrackerService())->getSensorStates(7, 30))->keyBy('id');
+
+        $this->assertSame('ok', $states['outdoor_temp_humidity']['state']);
+        $this->assertSame('stale', $states['solar']['state']);
+        $this->assertSame('failed', $states['wind']['state']);
+    }
+
+    public function test_cached_states_are_served_without_touching_the_readings_table(): void
+    {
+        WeatherReading::create([
+            'recorded_at' => now()->subMinute(),
+            'temperature' => 18.1,
+        ]);
+
+        $tracker = new SensorTrackerService();
+        $tracker->refreshSensorStates(7, 30);
+
+        DB::enableQueryLog();
+        $states = $tracker->getCachedSensorStates(7, 30);
+        $selects = collect(DB::getRawQueryLog())
+            ->filter(fn ($q) => str_contains($q['raw_query'], 'from "weather_readings"'))
+            ->count();
+        DB::disableQueryLog();
+
+        $this->assertSame(0, $selects);
+        $this->assertSame('outdoor_temp_humidity', $states[0]['id']);
+    }
+
+    /**
+     * getLastSeenForSensors() seeds its map with nulls and previously guarded
+     * writes with isset(), which is false for null — so no sensor ever got a
+     * last_seen and getFailedSensors() could never report anything.
+     */
+    public function test_reports_a_sensor_that_stopped_reporting(): void
+    {
+        WeatherReading::create([
+            'recorded_at' => now()->subHours(4),
+            'temperature' => 17.2,
+            'wind_speed' => 9.0,
+        ]);
+        WeatherReading::create([
+            'recorded_at' => now()->subMinute(),
+            'temperature' => 18.1,
+        ]);
+
+        $failed = (new SensorTrackerService())->getFailedSensors(7, 60);
+
+        $this->assertSame(['wind'], array_column($failed, 'id'));
+        $this->assertEqualsWithDelta(
+            now()->subHours(4)->timestamp,
+            $failed[0]['last_seen']->timestamp,
+            5
+        );
+    }
+
+    public function test_tracks_outdoor_thermo_hygrometer_from_normalized_fields(): void
+    {
+        $reading = new WeatherReading(['temperature' => 18.4, 'humidity' => 71]);
+
+        $ids = SensorTrackerService::getSensorIdsFromReading($reading);
+
+        $this->assertContains('outdoor_temp_humidity', $ids);
+    }
+
+    public function test_tracks_wind_rain_and_solar_independently(): void
+    {
+        $reading = new WeatherReading([
+            'wind_speed' => 12.0,
+            'rain_daily' => 0.0,
+            'solar_radiation' => 430.5,
+            'uv_index' => 4.0,
+        ]);
+
+        $ids = SensorTrackerService::getSensorIdsFromReading($reading);
+
+        $this->assertContains('wind', $ids);
+        $this->assertContains('rain', $ids);
+        $this->assertContains('solar', $ids);
+        $this->assertContains('uv', $ids);
+    }
+
+    /**
+     * A station that keeps publishing indoor values while the outdoor array is
+     * silent must not look healthy: the outdoor sensors have to drop out of the
+     * tracked set so their last_seen stops advancing.
+     */
+    public function test_indoor_only_reading_does_not_report_outdoor_sensors(): void
+    {
+        $reading = new WeatherReading([
+            'temperature_indoor' => 26.9,
+            'humidity_indoor' => 61,
+            'pressure_rel' => 1013.0,
+        ]);
+
+        $ids = SensorTrackerService::getSensorIdsFromReading($reading);
+
+        $this->assertContains('indoor_temp_humidity', $ids);
+        $this->assertContains('barometer', $ids);
+        $this->assertNotContains('outdoor_temp_humidity', $ids);
+        $this->assertNotContains('wind', $ids);
+        $this->assertNotContains('rain', $ids);
+    }
+
+    public function test_zero_is_a_reading_not_a_missing_sensor(): void
+    {
+        $reading = new WeatherReading(['temperature' => 0.0, 'wind_speed' => 0.0]);
+
+        $ids = SensorTrackerService::getSensorIdsFromReading($reading);
+
+        $this->assertContains('outdoor_temp_humidity', $ids);
+        $this->assertContains('wind', $ids);
+    }
+
+    public function test_still_tracks_ecowitt_battery_keys_and_extra_channels(): void
+    {
+        $reading = new WeatherReading([
+            'battery_status' => ['wh65batt' => 0, 'soilbatt1' => 1],
+            'temp_1' => 21.0,
+            'soil_moisture_2' => 34,
+        ]);
+
+        $ids = SensorTrackerService::getSensorIdsFromReading($reading);
+
+        $this->assertContains('wh65batt', $ids);
+        $this->assertContains('soilbatt1', $ids);
+        $this->assertContains('temp_1', $ids);
+        $this->assertContains('soil_2', $ids);
+    }
+
+    public function test_labels_primary_sensors_without_exposing_raw_ids(): void
+    {
+        $this->assertSame('Outdoor temp/humidity', SensorTrackerService::sensorIdToLabel('outdoor_temp_humidity'));
+        $this->assertSame('Wind sensor', SensorTrackerService::sensorIdToLabel('wind'));
+        $this->assertSame('Rain gauge', SensorTrackerService::sensorIdToLabel('rain'));
+    }
+}

--- a/tests/Unit/Services/Weather/SensorTrackerServiceTest.php
+++ b/tests/Unit/Services/Weather/SensorTrackerServiceTest.php
@@ -189,4 +189,12 @@ class SensorTrackerServiceTest extends TestCase
         $this->assertSame('Wind sensor', SensorTrackerService::sensorIdToLabel('wind'));
         $this->assertSame('Rain gauge', SensorTrackerService::sensorIdToLabel('rain'));
     }
+
+    /** batt1..8 are the extra channels' batteries; the raw key is not a label. */
+    public function test_labels_numbered_ecowitt_battery_channels(): void
+    {
+        $this->assertSame('Battery sensor 2', SensorTrackerService::sensorIdToLabel('batt2'));
+        $this->assertSame('Battery soil sensor 1', SensorTrackerService::sensorIdToLabel('soilbatt1'));
+        $this->assertSame('Battery wh65batt', SensorTrackerService::sensorIdToLabel('wh65batt'));
+    }
 }


### PR DESCRIPTION
A sensor went quiet on my station and I got no email. Turned out there were four separate reasons, each enough on its own.

**Nothing was ever reported as failed.** `getLastSeenForSensors()` seeded its map with nulls and guarded writes with `isset()`, which is false for null. So no sensor ever got a last-seen and `getFailedSensors()` always returned an empty array. This had never worked.

**The mail had nowhere to go.** `CheckSensorHealth` sent via an `alerts.email` key with no admin field, no seeder row and no handler. The only mention was a help page telling you to add it by hand. It also gated on `alerts.enabled`, the same setting that toggles weather warnings. Both commands now share one `NotificationDispatcher`, extracted from the sender that already worked in `FetchWeatherData`, so the address configured in Settings → Notifications applies everywhere.

**The main outdoor sensors weren't tracked.** Detection only knew Ecowitt battery keys and extra channels, so a gateway still publishing indoor values while the outdoor array was silent looked healthy. Sensors now come from the normalized reading columns, which every source writes.

**A failed send counted as sent.** The "already alerted" flag was set right after `sendAlert()` without checking the result, so a failure detected before notifications were configured silenced the alert for 24 hours after. It was also one boolean for all sensors, so a second sensor failing produced nothing.

Alongside those: the admin dashboard now lists every known sensor with ok/stale/failed and a last-seen time instead of dropping missing ones; the threshold is configurable and defaults to 30 minutes rather than 120; and a migration carries the settings to existing installs, since upgrades only run migrations and never the seeder.

Two things worth a look in review:

- Webhook deliveries now verify TLS. They previously ran with `CURLOPT_SSL_VERIFYPEER => false`. A webhook pointed at a self-signed host will start failing, with curl's reason in the log.
- Fetch alert subjects change from `[Weather Station]` to `[WeatherNode]`, since both senders share one formatter now.

Sensor state is cached and refreshed by the scheduled check. Computing it per request scanned the whole reading window, which on a station recording every minute took ~2.5s locally and showed up as a slow admin dashboard. The scheduled check went from two full scans to one.

357 tests, up from 342.