### PR TITLE
Fix Ambient current conditions becoming stale

### DIFF
--- a/app/Services/Weather/AmbientWeatherService.php
+++ b/app/Services/Weather/AmbientWeatherService.php
@@ -60,7 +60,9 @@ class AmbientWeatherService
 
         $cacheKey = "ambient_devices";
 
-        return Cache::remember($cacheKey, 3600, function () {
+        // The devices response includes lastData, so keep this cache below the
+        // five-minute sensor-health threshold used by the dashboard.
+        return Cache::remember($cacheKey, 30, function () {
             try {
                 $response = Http::timeout(10)->get($this->apiUrl, [
                     'apiKey' => $this->apiKey,

--- a/tests/Unit/AmbientWeatherServiceTest.php
+++ b/tests/Unit/AmbientWeatherServiceTest.php
@@ -77,14 +77,18 @@ class AmbientWeatherServiceTest extends TestCase
 
         $service = app(AmbientWeatherService::class);
 
-        $this->assertSame(10.0, $service->getCurrentConditions()['outdoor']['temperature']);
+        try {
+            $this->assertSame(10.0, $service->getCurrentConditions()['outdoor']['temperature']);
 
-        Carbon::setTestNow(now()->addSeconds(29));
-        $this->assertSame(10.0, $service->getCurrentConditions()['outdoor']['temperature']);
+            Carbon::setTestNow(now()->addSeconds(29));
+            $this->assertSame(10.0, $service->getCurrentConditions()['outdoor']['temperature']);
 
-        Carbon::setTestNow(now()->addSeconds(2));
-        $this->assertSame(20.0, $service->getCurrentConditions()['outdoor']['temperature']);
-        Http::assertSentCount(2);
+            Carbon::setTestNow(now()->addSeconds(2));
+            $this->assertSame(20.0, $service->getCurrentConditions()['outdoor']['temperature']);
+            Http::assertSentCount(2);
+        } finally {
+            Carbon::setTestNow();
+        }
     }
 
     private function configureCredentials(): void

--- a/tests/Unit/AmbientWeatherServiceTest.php
+++ b/tests/Unit/AmbientWeatherServiceTest.php
@@ -8,6 +8,7 @@ use App\Models\Setting;
 use App\Services\Weather\AmbientWeatherService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
@@ -64,6 +65,26 @@ class AmbientWeatherServiceTest extends TestCase
         $this->assertSame('Selected station', $conditions['device']['name']);
         $this->assertSame('AA:BB:CC:DD:EE:02', $conditions['device']['mac_address']);
         $this->assertSame(20.0, $conditions['outdoor']['temperature']);
+    }
+
+    public function test_current_conditions_cache_expires_before_sensor_health_threshold(): void
+    {
+        $this->configureCredentials();
+        Carbon::setTestNow('2026-08-17 12:00:00');
+        Http::fakeSequence()
+            ->push([$this->device('AA:BB:CC:DD:EE:01', 'Station', 50.0)], 200)
+            ->push([$this->device('AA:BB:CC:DD:EE:01', 'Station', 68.0)], 200);
+
+        $service = app(AmbientWeatherService::class);
+
+        $this->assertSame(10.0, $service->getCurrentConditions()['outdoor']['temperature']);
+
+        Carbon::setTestNow(now()->addSeconds(29));
+        $this->assertSame(10.0, $service->getCurrentConditions()['outdoor']['temperature']);
+
+        Carbon::setTestNow(now()->addSeconds(2));
+        $this->assertSame(20.0, $service->getCurrentConditions()['outdoor']['temperature']);
+        Http::assertSentCount(2);
     }
 
     private function configureCredentials(): void


### PR DESCRIPTION
## Summary

- reduce the Ambient `/v1/devices` cache from one hour to 30 seconds
- document why the TTL must remain below the dashboard's five-minute sensor-health threshold
- add a regression test proving current conditions refresh after the shortened cache window

The `/v1/devices` response contains `lastData`, so the previous one-hour TTL cached current observations as well as device metadata. The scheduler continued running but received the same timestamp until WeatherNode marked the station offline.

Fixes #60.

## Verification

- production Docker image builds successfully
- `php artisan test tests/Unit/AmbientWeatherServiceTest.php`
  - 4 tests
  - 10 assertions
- `git diff --check`
- local layered review: 0 failures
