### PR TITLE
Detect stale data sources, and stop a save failure taking the fetch down

### DIFF
--- a/app/Console/Commands/CheckSensorHealth.php
+++ b/app/Console/Commands/CheckSensorHealth.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Services\Notifications\NotificationDispatcher;
+use App\Support\CacheFreshness;
 use App\Services\Weather\SensorTrackerService;
 use Illuminate\Console\Command;
 use App\Models\WeatherReading;
@@ -204,15 +205,9 @@ class CheckSensorHealth extends Command
         $cacheKey = "yrno_forecast_{$latitude}_{$longitude}";
 
         $forecastData = Cache::get($cacheKey);
-        $lastUpdate = Cache::get("{$cacheKey}_updated_at");
 
-        $isStale = !$forecastData || ($lastUpdate && now()->diffInMinutes($lastUpdate) > 60);
-
-        $this->healthStatus['forecast'] = [
-            'is_stale' => (bool) $isStale,
-            'age_minutes' => $lastUpdate ? round(abs(now()->diffInMinutes($lastUpdate)), 1) : null,
-            'last_update' => $lastUpdate ? $lastUpdate->toIso8601String() : null,
-        ];
+        $this->healthStatus['forecast'] = $this->freshness($cacheKey, $forecastData);
+        $isStale = $this->healthStatus['forecast']['is_stale'];
 
         if ($isStale && $forecastData === null) {
             $this->sendAlertIfNeeded('forecast', 'Forecast Data (Yr.no)', 'Forecast data not available.');
@@ -223,30 +218,12 @@ class CheckSensorHealth extends Command
 
     private function checkAstronomyData()
     {
-        $sunData = Cache::get('astronomy_sun');
-        $sunUpdated = Cache::get('astronomy_sun_updated_at');
-
-        $isStale = !$sunData || ($sunUpdated && now()->diffInMinutes($sunUpdated) > 60);
-
-        $this->healthStatus['astronomy'] = [
-            'is_stale' => (bool) $isStale,
-            'age_minutes' => $sunUpdated ? round(abs(now()->diffInMinutes($sunUpdated)), 1) : null,
-            'last_update' => $sunUpdated ? $sunUpdated->toIso8601String() : null,
-        ];
+        $this->healthStatus['astronomy'] = $this->freshness('astronomy_sun', Cache::get('astronomy_sun'));
     }
 
     private function checkAuroraData()
     {
-        $auroraData = Cache::get('aurora_kp_index');
-        $auroraUpdated = Cache::get('aurora_kp_index_updated_at');
-
-        $isStale = !$auroraData || ($auroraUpdated && now()->diffInMinutes($auroraUpdated) > 60);
-
-        $this->healthStatus['aurora'] = [
-            'is_stale' => (bool) $isStale,
-            'age_minutes' => $auroraUpdated ? round(abs(now()->diffInMinutes($auroraUpdated)), 1) : null,
-            'last_update' => $auroraUpdated ? $auroraUpdated->toIso8601String() : null,
-        ];
+        $this->healthStatus['aurora'] = $this->freshness('aurora_kp_index', Cache::get('aurora_kp_index'));
     }
 
     private function checkAirQualityData()
@@ -260,16 +237,7 @@ class CheckSensorHealth extends Command
             ? "waqi_station_{$stationId}"
             : "waqi_{$latitude}_{$longitude}";
 
-        $airQuality = Cache::get($cacheKey);
-        $lastUpdate = Cache::get("{$cacheKey}_updated_at");
-
-        $isStale = !$airQuality || ($lastUpdate && now()->diffInMinutes($lastUpdate) > 60);
-
-        $this->healthStatus['airquality'] = [
-            'is_stale' => (bool) $isStale,
-            'age_minutes' => $lastUpdate ? round(abs(now()->diffInMinutes($lastUpdate)), 1) : null,
-            'last_update' => $lastUpdate ? $lastUpdate->toIso8601String() : null,
-        ];
+        $this->healthStatus['airquality'] = $this->freshness($cacheKey, Cache::get($cacheKey));
     }
 
     private function checkMetarData()
@@ -284,15 +252,29 @@ class CheckSensorHealth extends Command
         }
 
         $primaryIcao = Setting::getValue('metar.primary_icao', 'EHAM');
-        $metarData = Cache::get("metar_{$primaryIcao}");
-        $lastUpdate = Cache::get("metar_{$primaryIcao}_updated_at");
+        $this->healthStatus['metar'] = $this->freshness("metar_{$primaryIcao}", Cache::get("metar_{$primaryIcao}"));
+    }
 
-        $isStale = !$metarData || ($lastUpdate && now()->diffInMinutes($lastUpdate) > 60);
+    /**
+     * Freshness of a cached data source, from the write time recorded alongside
+     * the payload. A source is stale when the payload is gone, or when it was
+     * written longer than $maxAgeMinutes ago. This matters because payload TTLs
+     * are longer than the threshold, so an abandoned entry lingers as "healthy"
+     * for hours if only its presence is checked.
+     *
+     * @return array{is_stale: bool, age_minutes: float|null, last_update: string|null}
+     */
+    private function freshness(string $cacheKey, mixed $payload, int $maxAgeMinutes = 60): array
+    {
+        $lastUpdate = CacheFreshness::updatedAt($cacheKey);
 
-        $this->healthStatus['metar'] = [
-            'is_stale' => (bool) $isStale,
-            'age_minutes' => $lastUpdate ? round(abs(now()->diffInMinutes($lastUpdate)), 1) : null,
-            'last_update' => $lastUpdate ? $lastUpdate->toIso8601String() : null,
+        // Carbon 3 returns a signed diff, so compare the absolute age.
+        $ageMinutes = $lastUpdate ? round(abs(now()->diffInMinutes($lastUpdate)), 1) : null;
+
+        return [
+            'is_stale' => !$payload || ($ageMinutes !== null && $ageMinutes > $maxAgeMinutes),
+            'age_minutes' => $ageMinutes,
+            'last_update' => $lastUpdate?->toIso8601String(),
         ];
     }
 

--- a/app/Console/Commands/FetchWeatherData.php
+++ b/app/Console/Commands/FetchWeatherData.php
@@ -128,6 +128,11 @@ class FetchWeatherData extends Command
             if ($shouldSave) {
                 try {
                     $reading = $this->saveReading($format, $data, $ecowitt, $writer);
+
+                    if ($reading === null) {
+                        throw new \RuntimeException('The configured source reported no reading to save.');
+                    }
+
                     $this->info("Saved reading ID: {$reading->id}");
                     
                     // Clear error state on successful save
@@ -142,6 +147,8 @@ class FetchWeatherData extends Command
                         'format' => $format,
                         'error' => $e->getMessage(),
                     ]);
+
+                    $reading = null;
                 }
             }
 
@@ -155,6 +162,13 @@ class FetchWeatherData extends Command
                 ]);
             }
             
+            // Nothing was stored, so there is nothing to summarise. Both of the
+            // calls below require a reading, and passing the unset variable
+            // turned a handled save failure into a fatal scheduled task.
+            if (!$reading instanceof WeatherReading) {
+                return Command::FAILURE;
+            }
+
             // Update daily summary
             $this->updateDailySummary($reading);
             

--- a/app/Console/Commands/PollExternalData.php
+++ b/app/Console/Commands/PollExternalData.php
@@ -21,6 +21,7 @@ use App\Services\Solar\SolarForecastFactory;
 use App\Services\TideService;
 use App\Services\Wave\OpenMeteoWaveService;
 use App\Services\River\RijkswaterstaatRiverService;
+use App\Support\CacheFreshness;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -786,8 +787,8 @@ class PollExternalData extends Command
             $data = $service->fetchForecast();
 
             if ($data && isset($data['forecast']) && count($data['forecast']) > 0) {
-                Cache::put($sourceCacheKey, $data, now()->addMinutes($this->cacheTTLs['forecast']));
-                Cache::put($cacheKey, $data, now()->addMinutes($this->cacheTTLs['forecast']));
+                CacheFreshness::put($sourceCacheKey, $data, now()->addMinutes($this->cacheTTLs['forecast']));
+                CacheFreshness::put($cacheKey, $data, now()->addMinutes($this->cacheTTLs['forecast']));
                 $this->line("   Cached " . count($data['forecast']) . " forecast entries from {$sourceName}");
                 return true;
             }
@@ -884,7 +885,7 @@ class PollExternalData extends Command
             $data = $service->fetchAirQuality();
 
             if ($data) {
-                Cache::put($cacheKey, $data, now()->addMinutes($this->cacheTTLs['airquality']));
+                CacheFreshness::put($cacheKey, $data, now()->addMinutes($this->cacheTTLs['airquality']));
                 $aqi = $data['aqi'] ?? 'N/A';
                 $this->line("   Cached AQI: {$aqi}");
                 return true;
@@ -908,7 +909,7 @@ class PollExternalData extends Command
             $data = $service->getKpIndex();
 
             if ($data) {
-                Cache::put('aurora_kp_index', $data, now()->addMinutes($this->cacheTTLs['aurora']));
+                CacheFreshness::put('aurora_kp_index', $data, now()->addMinutes($this->cacheTTLs['aurora']));
                 $kp = $data['kp'] ?? 'N/A';
                 $this->line("   Cached Kp: {$kp}");
                 return true;
@@ -996,7 +997,7 @@ class PollExternalData extends Command
             $data = $service->fetchMetar($icaoArray);
 
             if ($data && !empty($data)) {
-                Cache::put($cacheKey, $data, now()->addMinutes($this->cacheTTLs['metar']));
+                CacheFreshness::put($cacheKey, $data, now()->addMinutes($this->cacheTTLs['metar']));
                 $this->line("   Cached METAR for {$primaryIcao}");
                 return true;
             }
@@ -1053,7 +1054,7 @@ class PollExternalData extends Command
             // Sun data
             $sunData = $service->getSunData();
             if ($sunData) {
-                Cache::put('astronomy_sun', $sunData, now()->addMinutes($this->cacheTTLs['astronomy']));
+                CacheFreshness::put('astronomy_sun', $sunData, now()->addMinutes($this->cacheTTLs['astronomy']));
                 $this->line("   Cached sun data (rise: {$sunData['sunrise']}, set: {$sunData['sunset']})");
             }
 
@@ -1102,7 +1103,7 @@ class PollExternalData extends Command
                 if (($data['category'] ?? '') === 'noise' && isset($data['values']['noise_LAeq']) && empty($data['noise_level'] ?? null)) {
                     $data['noise_level'] = $service->getNoiseDescription((float) $data['values']['noise_LAeq']);
                 }
-                Cache::put($cacheKey, $data, now()->addMinutes($this->cacheTTLs['airquality']));
+                CacheFreshness::put($cacheKey, $data, now()->addMinutes($this->cacheTTLs['airquality']));
                 $this->line("   Cached Luftdaten data (sensor: {$sensorId})");
                 return true;
             }

--- a/app/Services/AirQuality/WaqiService.php
+++ b/app/Services/AirQuality/WaqiService.php
@@ -3,6 +3,7 @@
 namespace App\Services\AirQuality;
 
 use App\Models\Setting;
+use App\Support\CacheFreshness;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -355,7 +356,7 @@ class WaqiService
                 $data = $response->json();
                 if (isset($data['status']) && $data['status'] === 'ok') {
                     $result = $this->parseAirQuality($data['data']);
-                    Cache::put($cacheKey, $result, 1800);
+                    CacheFreshness::put($cacheKey, $result, 1800);
                     return $result;
                 }
             }

--- a/app/Services/Forecast/YrNoService.php
+++ b/app/Services/Forecast/YrNoService.php
@@ -4,6 +4,7 @@ namespace App\Services\Forecast;
 
 use App\Contracts\Forecast\ForecastServiceInterface;
 use App\Models\Setting;
+use App\Support\CacheFreshness;
 use App\Services\UserAgentService;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Cache;
@@ -28,7 +29,7 @@ class YrNoService implements ForecastServiceInterface
     {
         $cacheKey = "yrno_forecast_{$this->latitude}_{$this->longitude}";
         
-        return Cache::remember($cacheKey, 1800, function () {
+        return CacheFreshness::remember($cacheKey, 1800, function () {
             try {
                 $http = Http::timeout(15);
                 if (!app()->environment('production') && env('HTTP_SKIP_TLS_VERIFY')) {

--- a/app/Support/CacheFreshness.php
+++ b/app/Support/CacheFreshness.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Carbon\Carbon;
+use Closure;
+use DateTimeInterface;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Cache writes that record when they happened.
+ *
+ * The cache stores no write time of its own, so freshness checks need a
+ * companion entry. Writing it here keeps the payload and its timestamp on the
+ * same TTL, rather than relying on every call site to remember both.
+ */
+class CacheFreshness
+{
+    public static function stampKey(string $key): string
+    {
+        return $key . '_updated_at';
+    }
+
+    public static function put(string $key, mixed $value, DateTimeInterface|int $ttl): mixed
+    {
+        Cache::put($key, $value, $ttl);
+        Cache::put(self::stampKey($key), now()->toIso8601String(), $ttl);
+
+        return $value;
+    }
+
+    public static function remember(string $key, DateTimeInterface|int $ttl, Closure $callback): mixed
+    {
+        $cached = Cache::get($key);
+        if (!is_null($cached)) {
+            return $cached;
+        }
+
+        return self::put($key, $callback(), $ttl);
+    }
+
+    public static function forget(string $key): void
+    {
+        Cache::forget($key);
+        Cache::forget(self::stampKey($key));
+    }
+
+    /**
+     * Accepts whatever the configured store hands back: an ISO string from
+     * put(), or a Carbon left by an older writer.
+     */
+    public static function updatedAt(string $key): ?Carbon
+    {
+        $raw = Cache::get(self::stampKey($key));
+
+        if ($raw instanceof DateTimeInterface) {
+            return Carbon::instance($raw);
+        }
+
+        if (is_int($raw)) {
+            return Carbon::createFromTimestamp($raw);
+        }
+
+        if (is_string($raw) && $raw !== '') {
+            try {
+                return Carbon::parse($raw);
+            } catch (\Exception) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/Console/FetchWeatherDataSaveFailureTest.php
+++ b/tests/Unit/Console/FetchWeatherDataSaveFailureTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console;
+
+use App\Models\Setting;
+use App\Models\WeatherReading;
+use App\Services\Weather\EcowittService;
+use App\Services\Weather\Normalization\WeatherReadingWriter;
+use App\Services\Weather\Sources\AmbientWeatherAdapter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FetchWeatherDataSaveFailureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function useAmbientSource(): void
+    {
+        Setting::setValue('livedata.format', 'AWapi', 'select', 'livedata');
+
+        $this->instance(AmbientWeatherAdapter::class, \Mockery::mock(AmbientWeatherAdapter::class, function ($mock) {
+            $mock->shouldReceive('fetch')->andReturn([
+                'recorded_at' => now(),
+                'temperature' => 12.3,
+                'humidity' => 70,
+            ]);
+        }));
+    }
+
+    /**
+     * The save failure is caught and logged, then $reading was passed straight
+     * to updateDailySummary(WeatherReading $reading), fataling the scheduled
+     * task with a TypeError instead of reporting the handled failure.
+     */
+    public function test_a_handled_save_failure_does_not_fatal_the_command(): void
+    {
+        $this->useAmbientSource();
+        $this->instance(WeatherReadingWriter::class, \Mockery::mock(WeatherReadingWriter::class, function ($mock) {
+            $mock->shouldReceive('store')->andThrow(new \RuntimeException('Integrity constraint violation'));
+        }));
+
+        $this->artisan('weather:fetch', ['--save' => true])->assertExitCode(1);
+
+        $this->assertSame(0, WeatherReading::count());
+    }
+
+    /** EcowittService::saveReading() is nullable, so the save can also just return nothing. */
+    public function test_a_save_returning_null_does_not_fatal_the_command(): void
+    {
+        Setting::setValue('livedata.format', 'ecoLcl', 'select', 'livedata');
+
+        $this->instance(EcowittService::class, \Mockery::mock(EcowittService::class, function ($mock) {
+            $mock->shouldReceive('fetchRealTimeData')->andReturn([
+                'recorded_at' => now(),
+                'temperature' => 12.3,
+            ]);
+            $mock->shouldReceive('saveReading')->andReturn(null);
+        }));
+
+        $this->artisan('weather:fetch', ['--save' => true])->assertExitCode(1);
+    }
+
+    public function test_a_successful_save_still_reports_success(): void
+    {
+        $this->useAmbientSource();
+
+        $this->artisan('weather:fetch', ['--save' => true])->assertExitCode(0);
+
+        $this->assertSame(1, WeatherReading::count());
+    }
+}

--- a/tests/Unit/Console/ForecastFreshnessHealthTest.php
+++ b/tests/Unit/Console/ForecastFreshnessHealthTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console;
+
+use App\Models\Setting;
+use App\Support\CacheFreshness;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class ForecastFreshnessHealthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function forecastKey(): string
+    {
+        return 'yrno_forecast_' . Setting::latitude() . '_' . Setting::longitude();
+    }
+
+    private function health(): array
+    {
+        $this->artisan('weather:check-sensor-health')->assertExitCode(0);
+
+        return Cache::get('data_source_health', [])['forecast'] ?? [];
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_reports_when_the_forecast_was_last_written(): void
+    {
+        CacheFreshness::put($this->forecastKey(), ['some' => 'forecast'], now()->addMinutes(120));
+
+        $forecast = $this->health();
+
+        $this->assertNotNull($forecast['last_update'], 'last_update was structurally always null.');
+        $this->assertNotNull($forecast['age_minutes']);
+        $this->assertFalse($forecast['is_stale']);
+    }
+
+    /**
+     * The payload TTL is 120 minutes, longer than the 60 minute staleness
+     * threshold, so old-but-present data used to report healthy for two hours.
+     */
+    public function test_marks_the_forecast_stale_once_the_cached_payload_is_old(): void
+    {
+        Carbon::setTestNow(now()->subMinutes(90));
+        CacheFreshness::put($this->forecastKey(), ['some' => 'forecast'], now()->addMinutes(120));
+        Carbon::setTestNow();
+
+        $forecast = $this->health();
+
+        $this->assertTrue($forecast['is_stale'], 'A 90 minute old forecast must not report healthy.');
+        $this->assertEqualsWithDelta(90, $forecast['age_minutes'], 1);
+    }
+}

--- a/tests/Unit/Support/CacheFreshnessTest.php
+++ b/tests/Unit/Support/CacheFreshnessTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use App\Support\CacheFreshness;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class CacheFreshnessTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_put_stores_the_payload_and_its_write_time(): void
+    {
+        Carbon::setTestNow('2026-08-18 09:00:00');
+
+        CacheFreshness::put('demo_key', ['a' => 1], now()->addMinutes(120));
+
+        $this->assertSame(['a' => 1], Cache::get('demo_key'));
+        $this->assertTrue(CacheFreshness::updatedAt('demo_key')->equalTo(now()));
+    }
+
+    public function test_updated_at_is_null_when_nothing_was_written(): void
+    {
+        $this->assertNull(CacheFreshness::updatedAt('demo_key'));
+    }
+
+    /** The stamp must survive whatever the configured cache store does to it. */
+    public function test_updated_at_reads_back_a_string_or_a_carbon(): void
+    {
+        Cache::put('a_updated_at', '2026-08-18T09:00:00+00:00', 600);
+        Cache::put('b_updated_at', Carbon::parse('2026-08-18 09:00:00', 'UTC'), 600);
+
+        $this->assertSame('2026-08-18 09:00:00', CacheFreshness::updatedAt('a')->utc()->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-08-18 09:00:00', CacheFreshness::updatedAt('b')->utc()->format('Y-m-d H:i:s'));
+    }
+
+    public function test_remember_stamps_the_entry_when_it_populates_the_cache(): void
+    {
+        Carbon::setTestNow('2026-08-18 09:00:00');
+
+        $value = CacheFreshness::remember('demo_key', 600, fn () => ['fresh' => true]);
+
+        $this->assertSame(['fresh' => true], $value);
+        $this->assertTrue(CacheFreshness::updatedAt('demo_key')->equalTo(now()));
+    }
+
+    public function test_forget_removes_the_stamp_too(): void
+    {
+        CacheFreshness::put('demo_key', 'v', 600);
+        CacheFreshness::forget('demo_key');
+
+        $this->assertNull(Cache::get('demo_key'));
+        $this->assertNull(CacheFreshness::updatedAt('demo_key'));
+    }
+}


### PR DESCRIPTION
Two bugs from `soend`, both in the health and fetch paths.

## Nothing was writing the freshness timestamps (#48)

`CheckSensorHealth` reads five `{key}_updated_at` cache keys to decide whether a source has gone quiet. Nothing ever wrote them: five reads, zero writes. So `last_update` and `age_minutes` were structurally always null, and the 60 minute staleness check collapsed to "is the entry present at all".

It matters because every affected payload is cached for longer than the threshold it was meant to enforce, 120 minutes for forecast, aurora, airquality and metar, 240 for astronomy. A poller could stop and the source kept reporting healthy until the entry expired hours later.

Reviving the stamp was not sufficient on its own. The comparison read

```php
$lastUpdate && now()->diffInMinutes($lastUpdate) > 60
```

and Carbon 3 returns a signed diff, so a 90 minute old entry gives `-90` and the check never fires. The `age_minutes` line directly beneath it already wrapped the same call in `abs()`, so the two had quietly drifted apart. Both now come from a single `freshness()` helper.

`CacheFreshness` writes the payload and its timestamp on the same TTL so they cannot expire separately, and normalises the stamp on read whatever the store hands back. Applied to the writers for the five checked sources in `PollExternalData`, plus `YrNoService` and `WaqiService`, which populate two of those keys directly.

This also fixes the symptom that led `soend` there: `radar.blade.php:980` reads `health_status.forecast.last_update` to show when the forecast was refreshed, so the "Updated: HH:MM" hint never rendered and a genuinely dry forecast was indistinguishable from a failed one.

## A handled save failure fataled the command (#36)

`saveReading()` throwing was caught, logged and alerted on, and then execution carried on into `updateDailySummary($reading)` with `$reading` never assigned. That parameter is typed `WeatherReading`, so a handled failure became an uncaught `TypeError` and the scheduled task exited 1.

Two more routes to the same fatal, beyond the one reported: `EcowittService::saveReading()` is nullable, so it is reachable with no exception at all, and the duplicate-skip path leaves `$reading` unset the same way. Tests cover the throw and the null.

## Verification

383 tests, 1200 assertions. New coverage: `CacheFreshnessTest` (5), `ForecastFreshnessHealthTest` (2, including a 90 minute old payload that previously reported healthy), `FetchWeatherDataSaveFailureTest` (3).