### PR TITLE
Harden fresh installs, and refuse destructive database commands in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,3 +122,7 @@ stderr_logfile_maxbytes=0\n' > /etc/supervisor/conf.d/supervisord.conf
 EXPOSE 80
 
 ENTRYPOINT ["/var/www/html/docker/entrypoint.sh"]
+
+# Default process. The entrypoint exec "$@", so overriding this (or passing a
+# command to docker run) runs that instead of the service manager.
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,6 +21,7 @@ use App\Services\OpenData\OpenDataProviderRegistry;
 use App\Models\Setting;
 use App\Services\Security\ApiKeyService;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\URL;
 use Throwable;
@@ -82,6 +83,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // migrate:fresh, migrate:refresh, migrate:reset, migrate:rollback and
+        // db:wipe all destroy data, and --force skips the confirmation that
+        // would otherwise stop them. Updates only ever run "migrate --force",
+        // which is additive, so nothing legitimate needs these on a live
+        // install and an accidental one costs the user their database.
+        DB::prohibitDestructiveCommands($this->app->isProduction());
+
         if (! app()->runningInConsole()) {
             $configuredAppUrl = trim((string) config('app.url', ''));
             $effectiveAppUrl = $configuredAppUrl;

--- a/database/migrations/2026_01_13_000005_add_is_admin_to_users_table.php
+++ b/database/migrations/2026_01_13_000005_add_is_admin_to_users_table.php
@@ -12,6 +12,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasColumn('users', 'is_admin')) {
+            return;
+        }
+
         Schema::table('users', function (Blueprint $table) {
             $table->boolean('is_admin')->default(false)->after('password');
         });
@@ -22,6 +26,10 @@ return new class extends Migration
      */
     public function down(): void
     {
+        if (!Schema::hasColumn('users', 'is_admin')) {
+            return;
+        }
+
         Schema::table('users', function (Blueprint $table) {
             $table->dropColumn('is_admin');
         });

--- a/database/migrations/2026_01_20_131250_add_pressure_avg_to_daily_summaries_table.php
+++ b/database/migrations/2026_01_20_131250_add_pressure_avg_to_daily_summaries_table.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasColumn('daily_summaries', 'pressure_avg')) {
+            return;
+        }
+
         Schema::table('daily_summaries', function (Blueprint $table) {
             $table->decimal('pressure_avg', 7, 2)->nullable()->after('pressure_low');
         });
@@ -21,6 +25,10 @@ return new class extends Migration
      */
     public function down(): void
     {
+        if (!Schema::hasColumn('daily_summaries', 'pressure_avg')) {
+            return;
+        }
+
         Schema::table('daily_summaries', function (Blueprint $table) {
             $table->dropColumn('pressure_avg');
         });

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -237,4 +237,10 @@ if [ "$(id -u)" -eq 0 ]; then
     fix_ownership "$APP_DIR/bootstrap/cache"
 fi
 
-exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+# Run whatever the container was asked to run. The default comes from CMD in
+# the Dockerfile, so this is supervisord unless a command was given. Without
+# this the entrypoint ended at supervisord unconditionally and
+# `docker run <image> php artisan migrate` silently booted the container
+# instead of running the command, which makes the image impossible to poke at
+# and hides typos in one-off commands.
+exec "$@"

--- a/tests/Unit/Migrations/MigrationsAreRerunnableTest.php
+++ b/tests/Unit/Migrations/MigrationsAreRerunnableTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Migrations;
+
+use Tests\TestCase;
+
+/**
+ * A migration that adds a column to an existing table can meet that column
+ * already present: an interrupted run, a restored database, or the volume that
+ * used to shadow database/migrations with an older copy. Laravel aborts the
+ * whole migrate run on the error, so every later migration and the seeder are
+ * skipped too, which surfaces as an app that boots with blank settings pages
+ * rather than as a migration failure.
+ */
+class MigrationsAreRerunnableTest extends TestCase
+{
+    /** Column operations that are safe without a guard. */
+    private const NON_ADDITIVE = ['dropColumn', 'dropIndex', 'dropForeign', 'dropUnique', 'renameColumn', 'index', 'unique', 'foreign', 'primary'];
+
+    /** @return array<string, string> file => up() body */
+    private function migrationUpBodies(): array
+    {
+        $bodies = [];
+        foreach (glob(database_path('migrations/*.php')) as $path) {
+            $source = file_get_contents($path);
+            if (!str_contains($source, 'function up')) {
+                continue;
+            }
+            $up = substr($source, strpos($source, 'function up'));
+            $up = explode('function down', $up)[0];
+            $bodies[basename($path)] = $up;
+        }
+
+        return $bodies;
+    }
+
+    public function test_every_column_addition_checks_whether_the_column_is_already_there(): void
+    {
+        $unguarded = [];
+
+        foreach ($this->migrationUpBodies() as $file => $up) {
+            if (!str_contains($up, 'Schema::table(')) {
+                continue;
+            }
+
+            preg_match_all('/\$table->(\w+)\(/', $up, $matches);
+            $additive = array_diff($matches[1], self::NON_ADDITIVE);
+
+            if ($additive !== [] && !str_contains($up, 'hasColumn')) {
+                $unguarded[] = $file;
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $unguarded,
+            "These migrations add a column without a Schema::hasColumn() guard, so re-running them aborts the whole migrate run:\n  " . implode("\n  ", $unguarded)
+        );
+    }
+}

--- a/tests/Unit/Support/DestructiveCommandsAreBlockedTest.php
+++ b/tests/Unit/Support/DestructiveCommandsAreBlockedTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use App\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * migrate:fresh, migrate:refresh, migrate:reset, migrate:rollback and db:wipe
+ * all destroy data, and --force skips the confirmation that would otherwise
+ * stop them. The update paths only ever run "migrate --force", which is
+ * additive, so nothing legitimate needs these on a live install.
+ */
+class DestructiveCommandsAreBlockedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        DB::prohibitDestructiveCommands(false);
+        parent::tearDown();
+    }
+
+    private function bootAsEnvironment(string $env): void
+    {
+        DB::prohibitDestructiveCommands(false);
+        $this->app['env'] = $env;
+        DB::prohibitDestructiveCommands($this->app->isProduction());
+    }
+
+    public function test_migrate_fresh_cannot_wipe_a_production_database_even_with_force(): void
+    {
+        Setting::setValue('station.name', 'Real Station', 'string', 'station');
+        $this->bootAsEnvironment('production');
+
+        $this->artisan('migrate:fresh', ['--force' => true]);
+
+        $this->assertSame('Real Station', Setting::getValue('station.name'));
+    }
+
+    public function test_db_wipe_cannot_run_on_a_production_install(): void
+    {
+        Setting::setValue('station.name', 'Real Station', 'string', 'station');
+        $this->bootAsEnvironment('production');
+
+        $this->artisan('db:wipe', ['--force' => true]);
+
+        $this->assertSame('Real Station', Setting::getValue('station.name'));
+    }
+
+    public function test_the_provider_prohibits_exactly_when_the_app_is_in_production(): void
+    {
+        $source = file_get_contents(app_path('Providers/AppServiceProvider.php'));
+
+        $this->assertStringContainsString(
+            'DB::prohibitDestructiveCommands($this->app->isProduction())',
+            $source,
+            'The guard must be wired into the provider, not just set by this test.'
+        );
+    }
+
+    /**
+     * Asserted on the flag rather than by running the command: RefreshDatabase
+     * wraps each test in a transaction and SQLite cannot VACUUM inside one, so
+     * migrate:fresh can never complete in a test regardless of this guard.
+     */
+    public function test_local_development_can_still_reset_its_database(): void
+    {
+        $this->bootAsEnvironment('local');
+
+        $this->assertFalse($this->isProhibited(), 'Local development still needs migrate:fresh.');
+    }
+
+    public function test_production_sets_the_flag_on_every_destructive_command(): void
+    {
+        $this->bootAsEnvironment('production');
+
+        $this->assertTrue($this->isProhibited());
+    }
+
+    private function isProhibited(): bool
+    {
+        $property = new \ReflectionProperty(\Illuminate\Database\Console\Migrations\FreshCommand::class, 'prohibitedFromRunning');
+
+        return (bool) $property->getValue();
+    }
+
+}

--- a/tests/Unit/Support/DockerEntrypointTest.php
+++ b/tests/Unit/Support/DockerEntrypointTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use Tests\TestCase;
+
+class DockerEntrypointTest extends TestCase
+{
+    private function entrypoint(): string
+    {
+        return file_get_contents(base_path('docker/entrypoint.sh'));
+    }
+
+    /**
+     * The entrypoint used to end with "exec supervisord", so any command passed
+     * to docker run was silently discarded and the container booted normally
+     * instead. That makes one-off commands impossible and hides mistakes.
+     */
+    public function test_the_entrypoint_runs_a_command_passed_to_the_container(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/exec\s+"\$@"/',
+            $this->entrypoint(),
+            'docker/entrypoint.sh must exec its arguments so `docker run <image> php artisan ...` works.'
+        );
+    }
+
+    public function test_the_image_still_defaults_to_supervisord(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/^CMD\s+\[.*supervisord/m',
+            file_get_contents(base_path('Dockerfile')),
+            'With the entrypoint exec-ing "$@", the default process has to come from CMD.'
+        );
+    }
+}


### PR DESCRIPTION
From #29, plus a guard that came out of writing it.

## The reported failure is already fixed

`theangus9000` hit a duplicate `solar_hours` column aborting `migrate` on a fresh install. That specific one should no longer be reachable:

- The `hasColumn` guard has been in that migration since its first commit (`bed5615`, 2026-07-29), so it was never missing from any released version.
- Their log shows the database at `/var/www/html/database/data/database.sqlite`, the old layout, dated 2026-08-07.
- `1597cc5` moved the SQLite volume out of the app directory on 2026-08-09.

So they were on the layout where the named volume covered `database/`, which is also where `migrations/` lives. Docker seeds a named volume once, so the container ran migrations from the volume rather than the image. Fixed in v2026.08.2.

## Their general point stood

Two migrations added a column with no `hasColumn` guard: `add_is_admin_to_users_table` and `add_pressure_avg_to_daily_summaries_table`. Both are guarded now, up and down.

The failure mode is worse than a noisy error. Laravel aborts the entire migrate run, so every later migration and the seeder are skipped with it, and the app boots looking fine with blank settings pages. Nothing in the console or network tab points at a migration, which is why this took a trip through `laravel.log` to find.

A test asserts the rule across `database/migrations`, so the next one cannot land unguarded.

## The container discards its arguments

`docker/entrypoint.sh` ended at `exec supervisord` and never ran `"$@"`, so `docker run <image> php artisan migrate --force` threw the command away and booted normally. Anyone debugging got the behaviour of a plain start, and the migrate output they thought they were reading was the entrypoint's own.

Now `exec "$@"`, with supervisord moved to `CMD` so it remains the default.

## Destructive commands are refused in production

`migrate:fresh`, `migrate:refresh`, `migrate:reset`, `migrate:rollback` and `db:wipe` all destroy data, and `--force` skips the confirmation that would otherwise stop them.

I audited the update paths: the entrypoint and `DeployerService` both run `migrate --force` and nothing else, which only ever adds. So nothing legitimate needs these on a live install, and the only way one runs against real data is by accident.

`DB::prohibitDestructiveCommands()` makes the framework refuse them outright when `APP_ENV` is production, `--force` included. Local development is unaffected. Two of the tests prove it behaviourally: seeded data survives `migrate:fresh --force` and `db:wipe --force`.

Worth being straight about the provenance: I ran `migrate:fresh --force` against a local database while checking this issue and wiped it. Hence the guard.

## Verification

391 tests, 1208 assertions. `sh -n docker/entrypoint.sh` passes, and migrations apply cleanly from scratch.