### PR TITLE
Accept RainViewer's hex frame ids so radar tiles load again

### DIFF
--- a/app/Http/Controllers/Api/TileProxyController.php
+++ b/app/Http/Controllers/Api/TileProxyController.php
@@ -58,12 +58,16 @@ class TileProxyController extends Controller
      * Proxy a radar tile from RainViewer with caching
      * 
      * URL format: /api/radar/tile/{path}/{size}/{z}/{x}/{y}/{color}/{options}.png
-     * Example: /api/radar/tile/v2/radar/1737561600/256/5/16/10/1/1_0.png
+     * Example: /api/radar/tile/v2/radar/c912c99f5a7d/512/7/73/38/1/1_0.png
      */
     public function tile(Request $request, string $path)
     {
         // Validate path format to prevent abuse
         if (!$this->isValidTilePath($path)) {
+            // Without the path there is nothing to diagnose from: the symptom
+            // is a blank radar and a wall of 400s with no reason attached.
+            Log::warning('Radar tile path rejected', ['path' => $path]);
+
             return response('Invalid tile path', 400);
         }
         
@@ -190,8 +194,19 @@ class TileProxyController extends Controller
             return false;
         }
         
-        // Must contain only safe characters
-        if (!preg_match('#^v2/radar/\d+/\d+/\d+/\d+/\d+/\d+/[\d_]+\.png$#', $path)) {
+        // Must contain only safe characters.
+        //
+        // The frame id was a Unix timestamp when this was written, so it was
+        // matched as \d+. RainViewer issues hex ids now (/v2/radar/c912c99f5a7d),
+        // and every tile the app requested was being refused by the app itself:
+        // /api/radar/frames hands the frontend these paths and this method then
+        // rejected them.
+        //
+        // Kept to lowercase alphanumerics rather than exactly hex, so another
+        // change to their id format does not blank the radar again. The pattern
+        // is still anchored to a RainViewer radar tile, and the id cannot hold a
+        // dot, a slash or an escape, so it grants no reach beyond that.
+        if (!preg_match('#^v2/radar/[0-9a-z]+/\d+/\d+/\d+/\d+/\d+/[\d_]+\.png$#', $path)) {
             return false;
         }
         
@@ -381,7 +396,12 @@ class TileProxyController extends Controller
     private function findCachedFallbackTileData(string $path): ?string
     {
         $normalizedPath = ltrim($path, '/');
-        if (!preg_match('#^v2/radar/\d+(/.+)$#', $normalizedPath, $matches)) {
+
+        // Same frame id shape as isValidTilePath(). This carried the numeric
+        // assumption too, so with hex ids the fallback bailed out and an
+        // upstream failure produced a transparent pixel rather than the last
+        // good tile for that cell.
+        if (!preg_match('#^v2/radar/[0-9a-z]+(/.+)$#', $normalizedPath, $matches)) {
             return null;
         }
 

--- a/tests/Feature/Api/RadarTilePathValidationTest.php
+++ b/tests/Feature/Api/RadarTilePathValidationTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Http\Middleware\ApiKeyMiddleware;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * The validator required the RainViewer frame id to be digits, which matched
+ * their old timestamp scheme. They now issue hex ids, so every tile the app
+ * asked for was rejected by the app itself: /api/radar/frames hands the
+ * frontend these paths and /api/radar/tile then refuses them.
+ */
+class RadarTilePathValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('local');
+        $this->withoutMiddleware(ApiKeyMiddleware::class);
+    }
+
+    /** Http::fake() merges stubs, so a success stub must not be registered globally. */
+    private function fakeUpstreamServesTile(): void
+    {
+        Http::fake(['tilecache.rainviewer.com/*' => Http::response(base64_decode(self::PNG_BASE64), 200, ['Content-Type' => 'image/png'])]);
+    }
+
+    private function tile(string $path)
+    {
+        return $this->get('/api/radar/tile/' . $path);
+    }
+
+    public function test_a_current_hex_frame_id_is_accepted(): void
+    {
+        $this->fakeUpstreamServesTile();
+        $response = $this->tile('v2/radar/c912c99f5a7d/512/7/73/38/1/1_0.png');
+
+        $response->assertOk();
+        $this->assertStringStartsWith('image/', (string) $response->headers->get('Content-Type'));
+    }
+
+    public function test_a_legacy_numeric_frame_id_still_works(): void
+    {
+        $this->fakeUpstreamServesTile();
+        $this->tile('v2/radar/1737561600/256/5/16/10/1/1_0.png')->assertOk();
+    }
+
+    public function test_path_traversal_is_still_refused(): void
+    {
+        $this->tile('v2/radar/../../../etc/passwd.png')->assertStatus(400);
+        $this->tile('v2/radar/abc/512/7/73/38/1/../../secret.png')->assertStatus(400);
+    }
+
+    public function test_a_non_radar_upstream_path_is_still_refused(): void
+    {
+        $this->tile('v2/satellite/c912c99f5a7d/512/7/73/38/1/1_0.png')->assertStatus(400);
+        $this->tile('v2/radar/c912c99f5a7d/512/7/73/38/1/1_0.jpg')->assertStatus(400);
+    }
+
+    public function test_nothing_outside_the_frame_id_alphabet_is_accepted(): void
+    {
+        $this->tile('v2/radar/abc%2F..%2F/512/7/73/38/1/1_0.png')->assertStatus(400);
+        $this->tile('v2/radar/ab.cd/512/7/73/38/1/1_0.png')->assertStatus(400);
+    }
+
+    /** A blank radar with a silent 400 gave nothing to diagnose from. */
+    public function test_a_rejected_path_is_logged(): void
+    {
+        Log::spy();
+
+        $this->tile('v2/radar/ab.cd/512/7/73/38/1/1_0.png')->assertStatus(400);
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn ($message, $context = []) => str_contains((string) $message, 'tile path')
+                && ($context['path'] ?? '') === 'v2/radar/ab.cd/512/7/73/38/1/1_0.png');
+    }
+
+    /**
+     * When upstream fails, the proxy serves the last good tile for the same map
+     * cell. That lookup carried the same numeric-id assumption, so with hex
+     * frames it bailed out and users got a transparent pixel instead.
+     */
+    public function test_a_failed_upstream_falls_back_to_the_previous_hex_frame(): void
+    {
+        \Illuminate\Support\Facades\Cache::put('rainviewer_frames', [
+            'version' => '2.0',
+            'generated' => time(),
+            'host' => 'https://tilecache.rainviewer.com',
+            'radar' => ['past' => [
+                ['time' => time() - 600, 'path' => '/v2/radar/aaaa11112222'],
+                ['time' => time(), 'path' => '/v2/radar/bbbb33334444'],
+            ]],
+        ], 1800);
+
+        $cell = '/512/7/73/38/1/1_0.png';
+        Storage::disk('local')->put('radar-tiles/v2/radar/aaaa11112222' . $cell, base64_decode(self::PNG_BASE64));
+
+        Http::fake(['tilecache.rainviewer.com/*' => Http::response('nope', 500)]);
+
+        $response = $this->tile('v2/radar/bbbb33334444' . $cell);
+
+        $response->assertOk();
+        $this->assertSame(base64_decode(self::PNG_BASE64), $response->getContent());
+    }
+
+    public function test_the_upstream_url_is_built_from_the_validated_path(): void
+    {
+        $this->fakeUpstreamServesTile();
+        $this->tile('v2/radar/c912c99f5a7d/512/7/73/38/1/1_0.png')->assertOk();
+
+        Http::assertSent(fn (Request $r) => str_contains($r->url(), '/v2/radar/c912c99f5a7d/512/7/73/38/1/1_0.png'));
+    }
+}


### PR DESCRIPTION
Fixes #35. `soend`'s report checks out, and there is a second instance of the same bug they did not mention.

## Confirmed against RainViewer

`isValidTilePath()` required the frame id to be digits, matching their old timestamp scheme. I queried their public API while writing this:

```
sample paths:
   /v2/radar/c912c99f5a7d
   /v2/radar/cf5480351a06
   /v2/radar/599f25f41537
frames total: 13, non-numeric ids: 13
```

Not one current frame is numeric, so every tile was rejected. The radar is blank for anyone proxying tiles, and it is not a recent regression: it broke whenever RainViewer changed their format.

The app was refusing paths it generated itself. `/api/radar/frames` proxies the frame list and rewrites `host` to `/api/radar/tile`, the frontend joins the two, and this validator rejected the result.

## The fix

The frame id is matched as lowercase alphanumeric rather than exactly hex, so another change to their id format does not blank the radar again. A third-party path format is not a good thing to pin precisely.

The pattern stays anchored to a RainViewer radar tile, and the id cannot contain a dot, a slash or an escape, so it grants no reach beyond that. Tests cover traversal, non-radar upstream paths, and the id alphabet, so the open-proxy concern the original comment guards against stays covered.

## Second instance

`findCachedFallbackTileData()` carried the same numeric assumption. That is the path which serves the last good tile for a map cell when upstream fails, so with hex ids it bailed out and users got a transparent pixel instead of the previous frame. Fixed alongside, with a test.

Worth noting how I found that test was initially worthless: it passed before I fixed anything. `Http::fake()` merges stubs, so the success stub from `setUp` still matched and upstream never failed. The success stub is opt-in now, and the test fails without the fix.

## Also

Rejections are logged with the offending path, `soend`'s second suggestion. `return response('Invalid tile path', 400)` discarded the one piece of information needed, which is why this surfaced as an unexplained blank map rather than an obvious answer in the log.

## Not done

Their other suggestion, validating the frame id against the cached frame list, would be tighter than any format guess and immune to the next change. I left it out: a tile for a frame that has just rotated out of the list would start 404ing despite being on disk, and the cache-miss path needs a fallback anyway. Worth its own change rather than being folded into a fix that needs to go out.

## Verification

417 tests, 1272 assertions. Eight new covering the hex id, the legacy numeric id, traversal, non-radar paths, the id alphabet, the log line, upstream URL construction, and the hex fallback.