### PR TITLE
Stop shipping defaults that point at one particular install

### DIFF
--- a/app/Console/Commands/MigrateHistoricalData.php
+++ b/app/Console/Commands/MigrateHistoricalData.php
@@ -24,7 +24,13 @@ class MigrateHistoricalData extends Command
 
     public function handle(): int
     {
-        $sourcePath = $this->argument('source_path') ?? '/Users/pauladmiraal/DEV/meteouitgeest_current/public_html';
+        $sourcePath = $this->argument('source_path');
+
+        if (!$sourcePath) {
+            $this->error('A source path is required: php artisan ' . $this->getName() . ' /path/to/old/public_html');
+
+            return Command::FAILURE;
+        }
         $wudataPath = $sourcePath . '/wudata';
 
         $this->info("🌤️  WeatherNode Historical Data Migration");

--- a/app/Services/Tide/NoaaSource.php
+++ b/app/Services/Tide/NoaaSource.php
@@ -63,7 +63,7 @@ class NoaaSource extends AbstractTideSource
             'datum'       => 'MSL',
             'units'       => 'metric',
             'time_zone'   => 'GMT',
-            'application' => 'meteouitgeest',
+            'application' => 'weathernode',
             'format'      => 'json',
         ];
 

--- a/database/migrations/2026_08_18_140000_clear_leftover_personal_defaults.php
+++ b/database/migrations/2026_08_18_140000_clear_leftover_personal_defaults.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Two settings shipped with values pointing at the install this project grew
+ * out of: its webcam image and its public URL. Anyone who never changed them
+ * has been showing someone else's webcam, and reporting someone else's address
+ * as their own site.
+ *
+ * Only rows still holding the shipped value are cleared. Nobody else would
+ * have typed these, so an exact match means the setting was never touched.
+ */
+return new class extends Migration
+{
+    private const LEFTOVERS = [
+        'webcam.url' => 'https://www.meteouitgeest.nl/thumbnail/image.jpg',
+        'station.server_url' => 'https://meteouitgeest.nl/',
+    ];
+
+    public function up(): void
+    {
+        foreach (self::LEFTOVERS as $key => $shippedValue) {
+            DB::table('settings')
+                ->where('key', $key)
+                ->where('value', $shippedValue)
+                ->update(['value' => '', 'updated_at' => now()]);
+
+            Cache::forget("setting.{$key}");
+        }
+    }
+
+    public function down(): void
+    {
+        // Restoring someone else's URLs would be the bug, not the fix.
+    }
+};

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -26,7 +26,7 @@ class SettingsSeeder extends Seeder
             ['key' => 'station.manufacturer', 'value' => 'fineoffset', 'type' => 'select', 'group' => 'station', 'description' => 'Weather station manufacturer', 'options' => 'fineoffset:Fine Offset/Ecowitt,davis:Davis Instruments,netatmo:Netatmo,ambient:Ambient Weather,weatherflow:WeatherFlow,other:Other'],
             ['key' => 'station.start_date', 'value' => '2020-12-06', 'type' => 'date', 'group' => 'station', 'description' => 'Date station started recording'],
             ['key' => 'station.wu_id', 'value' => 'IUITGE8', 'type' => 'string', 'group' => 'station', 'description' => 'Weather Underground Station ID'],
-            ['key' => 'station.server_url', 'value' => 'https://meteouitgeest.nl/', 'type' => 'string', 'group' => 'station', 'description' => 'Public URL of this weather site'],
+            ['key' => 'station.server_url', 'value' => '', 'type' => 'string', 'group' => 'station', 'description' => 'Public URL of this weather site (leave empty to use APP_URL)'],
 
             // ===== Live Data Source =====
             ['key' => 'livedata.format', 'value' => 'ecoLcl', 'type' => 'select', 'group' => 'livedata', 'description' => 'Primary live data format/source', 'options' => 'ecoLcl:Ecowitt Local (push),ecowittAPI:Ecowitt Cloud API,wu:Weather Underground,cumulus:Cumulus,weewx:WeeWX,weathercat:WeatherCat,DWL:WeatherLink Cloud v1,DWL_v2api:WeatherLink Cloud v2,DWL_v2api_demo:WeatherLink Cloud v2 (Demo Mode),meteohub:Meteohub,wswin:WSWIN,weatherlink:WeatherLink Local,wifilogger:WiFiLogger,MB_rt:Meteobridge (realtime.txt),wf:WeatherFlow,AWapi:Ambient Weather API,wd:Weather Display'],
@@ -197,7 +197,7 @@ class SettingsSeeder extends Seeder
 
             // ===== Webcam =====
             ['key' => 'webcam.enabled', 'value' => '1', 'type' => 'boolean', 'group' => 'webcam', 'description' => 'Enable webcam display'],
-            ['key' => 'webcam.url', 'value' => 'https://www.meteouitgeest.nl/thumbnail/image.jpg', 'type' => 'string', 'group' => 'webcam', 'description' => 'Webcam image URL'],
+            ['key' => 'webcam.url', 'value' => '', 'type' => 'string', 'group' => 'webcam', 'description' => 'Webcam image URL'],
             ['key' => 'webcam.refresh_interval', 'value' => '60', 'type' => 'integer', 'group' => 'webcam', 'description' => 'Webcam refresh interval (seconds)'],
             ['key' => 'webcam.full_image_url', 'value' => '', 'type' => 'string', 'group' => 'webcam', 'description' => 'Full resolution image URL (click to enlarge)'],
             ['key' => 'webcam.stream_url', 'value' => '', 'type' => 'string', 'group' => 'webcam', 'description' => 'Live stream URL (YouTube or Restreamer)'],

--- a/resources/views/weather/dashboard.blade.php
+++ b/resources/views/weather/dashboard.blade.php
@@ -370,7 +370,7 @@
             $ssrHybridCards[] = ['id' => 'radar', 'title' => __('Precipitation radar'), 'lines' => [__('Station') . ': ' . ((string) ($ssrStation['location'] ?? \App\Models\Setting::stationLocation()))]];
         }
         if ($ssrWidgetFlags['webcam']) {
-            $webcamUrl = (string) \App\Models\Setting::getValue('webcam.url', 'https://www.meteouitgeest.nl/thumbnail/image.jpg');
+            $webcamUrl = (string) \App\Models\Setting::getValue('webcam.url', '');
             $ssrHybridCards[] = ['id' => 'webcam', 'title' => __('Webcam'), 'lines' => [__('Source') . ': ' . $webcamUrl]];
         }
         if ($ssrWidgetFlags['aurora']) {
@@ -4109,7 +4109,7 @@
                      displayMode: '{{ \App\Models\Setting::getValue('webcam.display_mode', 'image') }}',
                      streamUrl: '{{ addslashes(\App\Models\Setting::getValue('webcam.stream_url', '')) }}',
                      streamType: '{{ \App\Models\Setting::getValue('webcam.stream_type', 'none') }}',
-                     imageUrl: '{{ \App\Models\Setting::getValue('webcam.url', 'https://www.meteouitgeest.nl/thumbnail/image.jpg') }}',
+                     imageUrl: '{{ \App\Models\Setting::getValue('webcam.url', '') }}',
                      showStreamModal: false,
                      imageUpdatedAt: null,
                      imageLoadFailed: false,
@@ -4489,8 +4489,17 @@
                         </template>
                     </div>
                     
+                    <!-- Nothing configured yet. Better than a broken image, and
+                         far better than the default this used to carry, which
+                         was the author's own webcam. -->
+                    <div x-show="(displayMode === 'image' || displayMode === 'both') && !imageUrl"
+                         class="absolute inset-0 flex items-center justify-center bg-black/40 text-sm text-gray-300"
+                         style="display: none;">
+                        📷 {{ __('Webcam not configured') }}
+                    </div>
+
                     <!-- Image display (when mode is 'image' or 'both') -->
-                    <div x-show="displayMode === 'image' || displayMode === 'both'"
+                    <div x-show="(displayMode === 'image' || displayMode === 'both') && imageUrl"
                          class="absolute inset-0"
                          style="display: none;">
                         <img id="webcam-image" 

--- a/tests/Feature/Defaults/NoPersonalDefaultsTest.php
+++ b/tests/Feature/Defaults/NoPersonalDefaultsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Defaults;
+
+use Tests\TestCase;
+
+/**
+ * WeatherNode ships from what began as one person's weather site. #12 cleaned
+ * up the visible branding, but several defaults still point at that install:
+ * its webcam, its public URL, and its name as the identifier sent to a
+ * third-party API. A fresh install should reference nobody in particular.
+ */
+class NoPersonalDefaultsTest extends TestCase
+{
+    /** @return list<string> */
+    private function shippedFiles(): array
+    {
+        return array_merge(
+            glob(database_path('seeders/*.php')),
+            glob(app_path('Services/*/*.php')),
+            glob(app_path('Console/Commands/*.php')),
+            [resource_path('views/weather/dashboard.blade.php')],
+        );
+    }
+
+    public function test_no_shipped_default_points_at_the_original_install(): void
+    {
+        $offenders = [];
+
+        foreach ($this->shippedFiles() as $file) {
+            $contents = file_get_contents($file);
+            foreach (explode("\n", $contents) as $number => $line) {
+                // The seeder's own docblock explains where the values came from.
+                if (str_contains($line, 'These values are taken from')) {
+                    continue;
+                }
+                if (stripos($line, 'meteouitgeest') !== false) {
+                    $offenders[] = basename($file) . ':' . ($number + 1);
+                }
+            }
+        }
+
+        $this->assertSame([], $offenders, "Shipped defaults still reference the original install:\n  " . implode("\n  ", $offenders));
+    }
+
+    public function test_no_command_defaults_to_a_developer_machine_path(): void
+    {
+        $offenders = [];
+
+        foreach (glob(app_path('Console/Commands/*.php')) as $file) {
+            if (preg_match('#/Users/[a-z]+/#i', file_get_contents($file))) {
+                $offenders[] = basename($file);
+            }
+        }
+
+        $this->assertSame([], $offenders, 'A command defaults to a path on someone\'s laptop: ' . implode(', ', $offenders));
+    }
+}

--- a/tests/Feature/Defaults/WebcamUnconfiguredTest.php
+++ b/tests/Feature/Defaults/WebcamUnconfiguredTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Defaults;
+
+use App\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WebcamUnconfiguredTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_an_unconfigured_webcam_says_so_rather_than_showing_someone_elses(): void
+    {
+        Setting::setValue('webcam.enabled', true, 'boolean', 'webcam');
+        Setting::setValue('webcam.url', '', 'string', 'webcam');
+
+        $response = $this->get('/');
+
+        $response->assertOk();
+        $response->assertDontSee('meteouitgeest.nl/thumbnail', false);
+        $response->assertSee('Webcam not configured');
+    }
+
+    public function test_a_configured_webcam_url_is_used(): void
+    {
+        Setting::setValue('webcam.enabled', true, 'boolean', 'webcam');
+        Setting::setValue('webcam.url', 'https://example.test/cam.jpg', 'string', 'webcam');
+
+        $this->get('/')->assertOk()->assertSee('https://example.test/cam.jpg', false);
+    }
+}

--- a/tests/Unit/Migrations/ClearLeftoverPersonalDefaultsMigrationTest.php
+++ b/tests/Unit/Migrations/ClearLeftoverPersonalDefaultsMigrationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ClearLeftoverPersonalDefaultsMigrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function storeSetting(string $key, string $value): void
+    {
+        DB::table('settings')->updateOrInsert(
+            ['key' => $key],
+            ['value' => $value, 'type' => 'string', 'group' => 'station', 'updated_at' => now(), 'created_at' => now()]
+        );
+    }
+
+    private function valueOf(string $key): ?string
+    {
+        return DB::table('settings')->where('key', $key)->value('value');
+    }
+
+    public function test_it_clears_settings_still_holding_the_shipped_value(): void
+    {
+        $this->storeSetting('webcam.url', 'https://www.meteouitgeest.nl/thumbnail/image.jpg');
+        $this->storeSetting('station.server_url', 'https://meteouitgeest.nl/');
+
+        $this->migration()->up();
+
+        $this->assertSame('', $this->valueOf('webcam.url'));
+        $this->assertSame('', $this->valueOf('station.server_url'));
+    }
+
+    public function test_it_leaves_a_configured_value_alone(): void
+    {
+        $this->storeSetting('webcam.url', 'https://example.test/cam.jpg');
+        $this->storeSetting('station.server_url', 'https://weather.example.test/');
+
+        $this->migration()->up();
+
+        $this->assertSame('https://example.test/cam.jpg', $this->valueOf('webcam.url'));
+        $this->assertSame('https://weather.example.test/', $this->valueOf('station.server_url'));
+    }
+
+    private function migration(): Migration
+    {
+        return require database_path('migrations/2026_08_18_140000_clear_leftover_personal_defaults.php');
+    }
+}


### PR DESCRIPTION
Investigating #42. The report is thin, so I want to be clear about what is established and what is inference.

## What I found

`webcam.url` ships as `https://www.meteouitgeest.nl/thumbnail/image.jpg`, in the seeder and in two fallbacks in the dashboard. **Any install that has not configured a webcam displays someone else's.**

That matches the report as well as anything could: "displaying a static image instead of loading the correct URL". From `dcorto`'s side it is a static image of a place in the Netherlands that has nothing to do with his station, and no URL he entered.

I cannot confirm that is what he hit, since the issue has no configuration or logs, so this is `Refs #42` rather than `Fixes`. I have asked him to confirm. It is worth fixing either way.

## Grepping for the pattern found three more

`#12` neutralised the visible branding but not these:

- **`station.server_url`** shipped as that site's address. `TelemetryService` reports it as the station's public URL, so every install that never changed it has been reporting the wrong site to the aggregator.
- **`NoaaSource`** sent `application=meteouitgeest` to NOAA on every tide request from every install. That field identifies the software making the call, so it names the project now.
- **`MigrateHistoricalData`** defaulted its source path to `/Users/pauladmiraal/DEV/...`. It asks for the path instead of guessing at a directory on one laptop.

## Upgrades

Both settings default to empty. An unconfigured webcam now says "Webcam not configured" rather than rendering a broken image, and telemetry already falls back to `APP_URL`.

A migration clears the two settings on existing installs, **but only where the value still matches what shipped**. Nobody else would have typed those URLs, so an exact match means the setting was never touched; anything customised is left alone. `down()` deliberately does nothing, since restoring someone else's URLs would be the bug rather than the fix.

## Keeping it fixed

A test asserts that no shipped default references that install, and that no command defaults to a path under `/Users`. It enumerated all six sites when I wrote it, which is how I found the last three.

## Verification

409 tests, 1246 assertions.