### PR TITLE
Ask the earthquake API for the area wanted, not the last N worldwide

### DIFF
--- a/app/Http/Controllers/Api/WeatherController.php
+++ b/app/Http/Controllers/Api/WeatherController.php
@@ -1016,9 +1016,28 @@ class WeatherController extends Controller
         // Get sort parameter
         $sort = $request->get('sort', 'time');
 
-        $cachedAll = Cache::get('earthquakes_all');
-        if (!is_array($cachedAll) || empty($cachedAll)) {
+        // 'nearby' by default: a site with a configured radius should not open
+        // on events thousands of kilometres away.
+        $scope = $request->get('scope') === 'all' ? 'all' : 'nearby';
+
+        if ($scope === 'nearby') {
             $cachedAll = Cache::get("earthquakes_{$latitude}_{$longitude}", []);
+
+            // The nearby list is populated by the scheduler. Until it has run,
+            // derive it from the worldwide list rather than showing nothing.
+            if (!is_array($cachedAll) || empty($cachedAll)) {
+                $radiusKm = (int) Setting::getValue('earthquakes.radius_km', 500);
+                $worldwide = Cache::get('earthquakes_all', []);
+                $cachedAll = array_values(array_filter(
+                    is_array($worldwide) ? $worldwide : [],
+                    fn ($eq) => is_array($eq) && isset($eq['distance']) && $eq['distance'] <= $radiusKm
+                ));
+            }
+        } else {
+            $cachedAll = Cache::get('earthquakes_all');
+            if (!is_array($cachedAll) || empty($cachedAll)) {
+                $cachedAll = Cache::get("earthquakes_{$latitude}_{$longitude}", []);
+            }
         }
 
         $earthquakes = array_values(array_filter(array_map(function ($eq) {
@@ -1065,6 +1084,7 @@ class WeatherController extends Controller
         return view('weather.earthquakes', [
             'earthquakes' => $earthquakes,
             'sort' => $sort,
+            'scope' => $scope,
             'stationLocation' => $stationLocation,
             'settings' => [
                 'latitude' => $latitude,

--- a/app/Services/Earthquake/EarthquakeService.php
+++ b/app/Services/Earthquake/EarthquakeService.php
@@ -15,6 +15,12 @@ class EarthquakeService
     private int $radiusKm;
     private float $minMagnitude;
     private string $apiUrl = 'https://www.seismicportal.eu/fdsnws/event/1/query';
+
+    /** Mean length of a degree of latitude, for converting the configured radius. */
+    private const KM_PER_DEGREE = 111.195;
+
+    /** How far back a worldwide lookup reaches. */
+    private const WORLDWIDE_WINDOW_DAYS = 7;
     
     // Magnitude classifications
     private array $magnitudeClasses = [
@@ -45,15 +51,32 @@ class EarthquakeService
 
         return Cache::remember($cacheKey, 120, function () use ($limit, $withinRadius) {
             try {
+                // Ask the API for the area or period wanted, rather than taking
+                // the last N events worldwide and filtering afterwards. At M2.5+
+                // those N events span roughly an hour of global seismicity, so a
+                // nearby quake almost never survived to be filtered.
+                $params = [
+                    'limit' => $limit,
+                    'format' => 'json',
+                    'minmag' => $this->minMagnitude,
+                ];
+
+                if ($withinRadius) {
+                    // FDSN maxradius is in degrees, not kilometres.
+                    $params['lat'] = $this->latitude;
+                    $params['lon'] = $this->longitude;
+                    $params['maxradius'] = round($this->radiusKm / self::KM_PER_DEGREE, 4);
+                } else {
+                    // Worldwide still needs a period, or it is again just the
+                    // last few minutes of global activity.
+                    $params['start'] = now()->subDays(self::WORLDWIDE_WINDOW_DAYS)->toIso8601String();
+                }
+
                 $response = Http::timeout(10)
                     ->withHeaders([
                         'User-Agent' => UserAgentService::forExternalApi(),
                     ])
-                    ->get($this->apiUrl, [
-                        'limit' => $limit,
-                        'format' => 'json',
-                        'minmag' => $this->minMagnitude,
-                    ]);
+                    ->get($this->apiUrl, $params);
 
                 if (!$response->successful()) {
                     Log::error('Seismic Portal request failed', [

--- a/resources/lang/en-gb.json
+++ b/resources/lang/en-gb.json
@@ -3287,5 +3287,8 @@
     "No settings registered for AEMET.": "No settings registered for AEMET.",
     "The AEMET integration allows querying daily and hourly weather forecasts for municipalities in Spain.": "The AEMET integration allows querying daily and hourly weather forecasts for municipalities in Spain.",
     "The Municipality Code is the 5-digit INE code (e.g. 28079 for Madrid, 08019 for Barcelona).": "The Municipality Code is the 5-digit INE code (e.g. 28079 for Madrid, 08019 for Barcelona).",
-    "e.g. 28079": "e.g. 28079"
+    "e.g. 28079": "e.g. 28079",
+    "Nearby earthquakes": "Nearby",
+    "Show": "Show",
+    "Worldwide": "Worldwide"
 }

--- a/resources/lang/en-us.json
+++ b/resources/lang/en-us.json
@@ -3287,5 +3287,8 @@
     "No settings registered for AEMET.": "No settings registered for AEMET.",
     "The AEMET integration allows querying daily and hourly weather forecasts for municipalities in Spain.": "The AEMET integration allows querying daily and hourly weather forecasts for municipalities in Spain.",
     "The Municipality Code is the 5-digit INE code (e.g. 28079 for Madrid, 08019 for Barcelona).": "The Municipality Code is the 5-digit INE code (e.g. 28079 for Madrid, 08019 for Barcelona).",
-    "e.g. 28079": "e.g. 28079"
+    "e.g. 28079": "e.g. 28079",
+    "Nearby earthquakes": "Nearby",
+    "Show": "Show",
+    "Worldwide": "Worldwide"
 }

--- a/resources/lang/it-it.json
+++ b/resources/lang/it-it.json
@@ -2801,5 +2801,8 @@
     "No settings registered for AEMET.": "Nessuna impostazione registrata per AEMET.",
     "The AEMET integration allows querying daily and hourly weather forecasts for municipalities in Spain.": "L'integrazione AEMET consente di consultare le previsioni meteorologiche giornaliere e orarie per i comuni in Spagna.",
     "The Municipality Code is the 5-digit INE code (e.g. 28079 for Madrid, 08019 for Barcelona).": "Il codice comune è il codice INE a 5 cifre (es. 28079 per Madrid, 08019 per Barcellona).",
-    "e.g. 28079": "es. 28079"
+    "e.g. 28079": "es. 28079",
+    "Nearby earthquakes": "Vicino a te",
+    "Show": "Mostra",
+    "Worldwide": "Nel mondo"
 }

--- a/resources/lang/nl-nl.json
+++ b/resources/lang/nl-nl.json
@@ -3233,5 +3233,8 @@
     "No settings registered for AEMET.": "Geen instellingen geregistreerd voor AEMET.",
     "The AEMET integration allows querying daily and hourly weather forecasts for municipalities in Spain.": "De AEMET-integratie maakt het mogelijk om dagelijkse en uurlijkse weersverwachtingen op te vragen voor Spaanse gemeenten.",
     "The Municipality Code is the 5-digit INE code (e.g. 28079 for Madrid, 08019 for Barcelona).": "De gemeentecode is de 5-cijferige INE-code (bijv. 28079 voor Madrid, 08019 for Barcelona).",
-    "e.g. 28079": "bijv. 28079"
+    "e.g. 28079": "bijv. 28079",
+    "Nearby earthquakes": "In de buurt",
+    "Show": "Toon",
+    "Worldwide": "Wereldwijd"
 }

--- a/resources/views/weather/earthquakes.blade.php
+++ b/resources/views/weather/earthquakes.blade.php
@@ -18,18 +18,31 @@
         </a>
     </div>
 
-    <!-- Sort Options -->
-    <div class="flex items-center gap-4 text-sm">
-        <span class="text-gray-400">{{ __('Sort by') }}:</span>
-        <a href="?sort=time" class="px-3 py-1 rounded-lg {{ $sort === 'time' ? 'bg-blue-500/20 text-blue-400' : 'text-gray-400 hover:text-white' }}">
-            {{ __('Time') }}
-        </a>
-        <a href="?sort=magnitude" class="px-3 py-1 rounded-lg {{ $sort === 'magnitude' ? 'bg-blue-500/20 text-blue-400' : 'text-gray-400 hover:text-white' }}">
-            {{ __('Magnitude') }}
-        </a>
-        <a href="?sort=distance" class="px-3 py-1 rounded-lg {{ $sort === 'distance' ? 'bg-blue-500/20 text-blue-400' : 'text-gray-400 hover:text-white' }}">
-            {{ __('Distance') }}
-        </a>
+    <!-- Scope + Sort Options -->
+    <div class="flex flex-wrap items-center gap-x-6 gap-y-3 text-sm">
+        <div class="flex items-center gap-2">
+            <span class="text-gray-400">{{ __('Show') }}:</span>
+            {{-- "Nearby earthquakes" rather than "Nearby": that string is already
+                 translated as the METAR nearest-airport label in some locales. --}}
+            <a href="?scope=nearby&sort={{ $sort }}" class="px-3 py-1 rounded-lg {{ $scope === 'nearby' ? 'bg-blue-500/20 text-blue-400' : 'text-gray-400 hover:text-white' }}">
+                {{ __('Nearby earthquakes') }}
+            </a>
+            <a href="?scope=all&sort={{ $sort }}" class="px-3 py-1 rounded-lg {{ $scope === 'all' ? 'bg-blue-500/20 text-blue-400' : 'text-gray-400 hover:text-white' }}">
+                {{ __('Worldwide') }}
+            </a>
+        </div>
+        <div class="flex items-center gap-2">
+            <span class="text-gray-400">{{ __('Sort by') }}:</span>
+            <a href="?scope={{ $scope }}&sort=time" class="px-3 py-1 rounded-lg {{ $sort === 'time' ? 'bg-blue-500/20 text-blue-400' : 'text-gray-400 hover:text-white' }}">
+                {{ __('Time') }}
+            </a>
+            <a href="?scope={{ $scope }}&sort=magnitude" class="px-3 py-1 rounded-lg {{ $sort === 'magnitude' ? 'bg-blue-500/20 text-blue-400' : 'text-gray-400 hover:text-white' }}">
+                {{ __('Magnitude') }}
+            </a>
+            <a href="?scope={{ $scope }}&sort=distance" class="px-3 py-1 rounded-lg {{ $sort === 'distance' ? 'bg-blue-500/20 text-blue-400' : 'text-gray-400 hover:text-white' }}">
+                {{ __('Distance') }}
+            </a>
+        </div>
     </div>
 
     @if(count($earthquakes) > 0)

--- a/tests/Feature/EarthquakesPageScopeTest.php
+++ b/tests/Feature/EarthquakesPageScopeTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class EarthquakesPageScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Setting::setValue('station.latitude', '52.5164', 'float', 'station');
+        Setting::setValue('station.longitude', '4.7079', 'float', 'station');
+        Setting::setValue('earthquakes.radius_km', '500', 'integer', 'earthquakes');
+        Setting::setValue('earthquakes.enabled', true, 'boolean', 'earthquakes');
+
+        Cache::put("earthquakes_52.5164_4.7079", [
+            ['id' => 'n1', 'magnitude' => 3.1, 'location' => 'NEARBY PLACE', 'distance' => 120, 'time' => '2026-08-18T10:00:00Z'],
+        ], 600);
+        Cache::put('earthquakes_all', [
+            ['id' => 'n1', 'magnitude' => 3.1, 'location' => 'NEARBY PLACE', 'distance' => 120, 'time' => '2026-08-18T10:00:00Z'],
+            ['id' => 'f1', 'magnitude' => 6.2, 'location' => 'FAR AWAY PLACE', 'distance' => 9000, 'time' => '2026-08-18T11:00:00Z'],
+        ], 600);
+    }
+
+    /** A site with a configured radius should not open on events 9000km away. */
+    public function test_it_defaults_to_nearby(): void
+    {
+        $response = $this->get('/earthquakes');
+
+        $response->assertOk();
+        $response->assertSee('NEARBY PLACE');
+        $response->assertDontSee('FAR AWAY PLACE');
+    }
+
+    public function test_worldwide_is_available_on_request(): void
+    {
+        $response = $this->get('/earthquakes?scope=all');
+
+        $response->assertOk();
+        $response->assertSee('FAR AWAY PLACE');
+    }
+
+    public function test_an_unknown_scope_falls_back_to_nearby(): void
+    {
+        $this->get('/earthquakes?scope=' . urlencode('../etc'))
+            ->assertOk()
+            ->assertDontSee('FAR AWAY PLACE');
+    }
+
+    /**
+     * "Nearby" is already translated in some locales as the METAR
+     * nearest-airport label, so the earthquakes UI must not reuse that string.
+     * In Italian it reads "Aeroporto Vicino", ie "Nearby Airport".
+     */
+    public function test_the_nearby_label_is_not_the_metar_airport_translation(): void
+    {
+        // LocaleUnitsMiddleware sets the locale per request, so setLocale()
+        // beforehand does not survive. Configure it the way the app does.
+        Setting::setValue('display.language', 'it-it', 'select', 'display');
+
+        $response = $this->get('/earthquakes');
+
+        $response->assertOk();
+        $response->assertSee('Vicino a te');
+        $response->assertDontSee('Aeroporto Vicino');
+    }
+
+    public function test_switching_scope_keeps_the_chosen_sort(): void
+    {
+        $response = $this->get('/earthquakes?scope=all&sort=magnitude');
+
+        $response->assertOk();
+        $response->assertSee('?scope=nearby&sort=magnitude', false);
+    }
+}

--- a/tests/Unit/Services/Earthquake/EarthquakeServiceTest.php
+++ b/tests/Unit/Services/Earthquake/EarthquakeServiceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Earthquake;
+
+use App\Models\Setting;
+use App\Services\Earthquake\EarthquakeService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * The query carried no geographic or time bound, so the API returned the last N
+ * events worldwide and the radius filter ran afterwards on that set. Global
+ * seismicity being what it is, those N events span about an hour, so a nearby
+ * quake essentially never appeared. Checked against the live API while writing
+ * this: 30 events at M2.5+ covered 66 minutes, across Hawaii, Chile, India and
+ * Indonesia.
+ */
+class EarthquakeServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+        Setting::setValue('station.latitude', '52.5164', 'float', 'station');
+        Setting::setValue('station.longitude', '4.7079', 'float', 'station');
+        Setting::setValue('earthquakes.radius_km', '500', 'integer', 'earthquakes');
+        Setting::setValue('earthquakes.min_magnitude', '2.5', 'float', 'earthquakes');
+    }
+
+    /** Http::fake() merges stubs, so an empty response must not be registered globally. */
+    private function fakeNoEvents(): void
+    {
+        Http::fake(['seismicportal.eu/*' => Http::response(['features' => []])]);
+    }
+
+    private function queryOf(Request $request): array
+    {
+        parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+
+        return $query;
+    }
+
+    public function test_a_nearby_lookup_asks_the_api_for_that_area(): void
+    {
+        $this->fakeNoEvents();
+        app(EarthquakeService::class)->fetchEarthquakes(30, true);
+
+        Http::assertSent(function (Request $request) {
+            $q = $this->queryOf($request);
+
+            // maxradius is in degrees, not kilometres: 500 / 111.195.
+            return abs((float) $q['lat'] - 52.5164) < 0.001
+                && abs((float) $q['lon'] - 4.7079) < 0.001
+                && abs((float) $q['maxradius'] - 4.4966) < 0.01;
+        });
+    }
+
+    public function test_a_worldwide_lookup_asks_for_a_time_window_instead_of_the_last_n_events(): void
+    {
+        $this->fakeNoEvents();
+        app(EarthquakeService::class)->fetchEarthquakes(100, false);
+
+        Http::assertSent(function (Request $request) {
+            $q = $this->queryOf($request);
+
+            return !isset($q['maxradius'])
+                && isset($q['start'])
+                && strtotime($q['start']) < strtotime('-24 hours');
+        });
+    }
+
+    public function test_the_magnitude_threshold_is_still_applied(): void
+    {
+        $this->fakeNoEvents();
+        app(EarthquakeService::class)->fetchEarthquakes(30, true);
+
+        Http::assertSent(fn (Request $request) => (float) $this->queryOf($request)['minmag'] === 2.5);
+    }
+
+    /** The client-side distance check stays as a backstop on whatever comes back. */
+    public function test_anything_outside_the_radius_is_still_discarded(): void
+    {
+        Http::fake(['seismicportal.eu/*' => Http::response(['features' => [
+            ['id' => 'near', 'properties' => ['mag' => 3.0, 'time' => '2026-08-18T10:00:00Z', 'flynn_region' => 'NEARBY'],
+             'geometry' => ['coordinates' => [4.9, 52.4, 10]]],
+            ['id' => 'far', 'properties' => ['mag' => 6.0, 'time' => '2026-08-18T10:00:00Z', 'flynn_region' => 'CHILE'],
+             'geometry' => ['coordinates' => [-70.0, -23.0, 10]]],
+        ]])]);
+
+        $result = app(EarthquakeService::class)->fetchEarthquakes(30, true);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('NEARBY', $result[0]['location']);
+    }
+}


### PR DESCRIPTION
`baldomax`'s report in #54, with the diagnosis and the Italian strings from them. All three problems check out.

## The query had no geographic or time bound

`fetchEarthquakes()` sent only `limit`, `format` and `minmag`. `$withinRadius` only affected the cache key, so the API returned the most recent events worldwide and the radius filter ran afterwards on whatever came back.

That set is far narrower than it looks. Against the live API just now, the exact query the app was sending:

```
events: 30
newest: 2026-08-18T14:18:38Z
oldest: 2026-08-18T13:12:45Z
first 5 regions: HAWAII, CHILE, INDIA, INDONESIA, INDONESIA
```

**Thirty events spanning 66 minutes across four continents.** A quake near the station essentially never survived to be filtered, and the page showed the newest global events, which read as nearby.

With the parameters this PR adds, same station, 500km:

```
events: 2
  2026-08-13T20:39  M3.7  493km  FRANCE
  2026-06-17T10:10  M2.5  480km  FRANCE-GERMANY BORDER REGION
```

Both genuinely within the radius, spanning two months. `maxradius` is in degrees, not kilometres, which is the part most likely to be got wrong later, so it is named in a constant and asserted in a test. The client-side distance check stays as a backstop.

## The page always showed the global list

It now defaults to nearby with a toggle for worldwide that preserves the chosen sort. An unrecognised `scope` falls back to nearby. Until the scheduler has filled the nearby cache, the page derives it from the worldwide list rather than showing nothing.

## The Italian label read "Nearby Airport"

Confirmed: `it-it.json` maps `"Nearby"` to `"Aeroporto Vicino"`, the METAR nearest-airport label. Laravel keys JSON translations by the English string, so reusing `Nearby` inherited it. The label is `Nearby earthquakes` now, with a test rendering the page in Italian and asserting it does not say "Aeroporto Vicino".

## Translations

Added `Show`, `Nearby earthquakes` and `Worldwide` to `en-us`, `en-gb`, `it-it` (from the reporter) and `nl-nl`.

**The other 14 locales fall back to English for these three strings.** I would rather leave that visible than invent translations for languages I cannot check. `baldomax` raised the same point in the issue.

Inserted textually rather than re-serialised: the files are not strictly sorted, and rewriting them produced a 1477-line diff per file before I noticed.

## Verification

412 tests, 1252 assertions. Nine new, covering the query parameters for both scopes, the magnitude threshold, the distance backstop, the page default, the worldwide toggle, an unrecognised scope, sort preservation, and the Italian label.