### PR TITLE
Declare the test suite's memory limit instead of inheriting it

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,10 @@
         </include>
     </source>
     <php>
+        <!-- The suite peaks at 127M against PHP's 128M default, so the next
+             test added crosses it. Declared here rather than left to whatever
+             php.ini a contributor or CI runner happens to have. -->
+        <ini name="memory_limit" value="512M"/>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>


### PR DESCRIPTION
One line in `phpunit.xml`. Worth being straight about what this is and is not.

## It is not fixing a failure

The suite passes on current main at PHP's 128M default:

```
Time: 01:04.390, Memory: 127.00 MB
OK (432 tests, 1300 assertions)
```

I earlier reported it exhausting memory after the four radar/translation PRs merged. That came from one run on a scratch merge branch and **does not reproduce**. I should have re-run before raising it.

## What is true

127M against a 128M default is a one megabyte margin, so the next test added crosses it. When it does, the failure is an OOM stack trace with no indication of the cause. I hit that during the translation work and spent a while blaming the locale files, which contribute 0.63M of the 127.

Setting it here rather than leaving it to whichever `php.ini` happens to be in front of the suite: a contributor's machine, or the runner used by `release.yml`, which runs `php artisan test` on pushes to main.

512M is arbitrary but ample; the point is that it is declared rather than inherited.

## Verified, not assumed

Launched at `-d memory_limit=64M`, the limit read from inside the suite:

```
with this change:     512M
without this change:   64M
```

So the directive applies, which the exit code alone could not have shown, since the suite passes either way at 128M.

## No effect on installs

The suite does not run in the deploy ZIP flow, the Docker image, or the in-app updater. A request loads one locale file at 0.63M against roughly 40M for the request, and the php-fpm pool sizing in the entrypoint budgets 64M per worker.