### PR TITLE
Let marine data use a coastal point instead of the station

### DIFF
--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -2836,6 +2836,12 @@ class SettingsController extends Controller
     private function updateWavesSettings(Request $request): void
     {
         Setting::setValue('waves.enabled', $request->input('waves_enabled') === '1', 'boolean', 'waves');
+
+        // Blank means "use the station", so empty is stored rather than rejected.
+        foreach (['latitude', 'longitude'] as $part) {
+            $value = trim((string) $request->input("marine_{$part}", ''));
+            Setting::setValue("marine.{$part}", $value, 'string', 'marine');
+        }
     }
 
     /**

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -168,6 +168,28 @@ class Setting extends Model
         return (float) static::getValue('station.longitude', 4.7078991);
     }
 
+    /**
+     * Where marine data is fetched for: waves, sea temperature and the tide
+     * sources that look up a grid cell rather than a named station.
+     *
+     * Falls back to the station. These APIs only cover ocean cells, so an
+     * inland station gets nothing back, and moving the station coordinates is
+     * not an option because every other reading uses them.
+     */
+    public static function marineLatitude(): float
+    {
+        $value = trim((string) (static::getValue('marine.latitude', '') ?? ''));
+
+        return $value !== '' ? (float) $value : static::latitude();
+    }
+
+    public static function marineLongitude(): float
+    {
+        $value = trim((string) (static::getValue('marine.longitude', '') ?? ''));
+
+        return $value !== '' ? (float) $value : static::longitude();
+    }
+
     public static function timezone(): string
     {
         return static::getValue('station.timezone', 'Europe/Amsterdam');

--- a/app/Services/Tide/CopernicusMarineSource.php
+++ b/app/Services/Tide/CopernicusMarineSource.php
@@ -65,8 +65,8 @@ class CopernicusMarineSource extends AbstractTideSource
     {
         $username  = Setting::getValue('tide.copernicus_username', '');
         $password  = Setting::getValue('tide.copernicus_password', '');
-        $latitude  = (float) Setting::latitude();
-        $longitude = (float) Setting::longitude();
+        $latitude  = Setting::marineLatitude();
+        $longitude = Setting::marineLongitude();
         $now       = now();
 
         if (empty($username) || empty($password)) {

--- a/app/Services/Tide/MareaSource.php
+++ b/app/Services/Tide/MareaSource.php
@@ -41,8 +41,8 @@ class MareaSource extends AbstractTideSource
     public function fetchTideData(string $stationCode = ''): array
     {
         $apiKey    = Setting::getValue('tide.marea_api_key', '');
-        $latitude  = (float) Setting::latitude();
-        $longitude = (float) Setting::longitude();
+        $latitude  = Setting::marineLatitude();
+        $longitude = Setting::marineLongitude();
         $now       = now();
 
         $params = [

--- a/app/Services/Tide/OpenMeteoMarineSource.php
+++ b/app/Services/Tide/OpenMeteoMarineSource.php
@@ -35,8 +35,8 @@ class OpenMeteoMarineSource extends AbstractTideSource
 
     public function fetchTideData(string $stationCode = ''): array
     {
-        $latitude  = (float) Setting::latitude();
-        $longitude = (float) Setting::longitude();
+        $latitude  = Setting::marineLatitude();
+        $longitude = Setting::marineLongitude();
         $now       = now();
 
         $response = Http::timeout(15)->get(self::API_BASE, [

--- a/app/Services/Wave/OpenMeteoWaveService.php
+++ b/app/Services/Wave/OpenMeteoWaveService.php
@@ -32,8 +32,8 @@ class OpenMeteoWaveService
 
     public function fetch(): array
     {
-        $latitude  = (float) Setting::latitude();
-        $longitude = (float) Setting::longitude();
+        $latitude  = Setting::marineLatitude();
+        $longitude = Setting::marineLongitude();
         $now       = now();
 
         $response = Http::timeout(15)->get(self::API_BASE, [

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -146,6 +146,10 @@ class SettingsSeeder extends Seeder
             ['key' => 'metar.airport_distance', 'value' => '34', 'type' => 'integer', 'group' => 'aviation', 'description' => 'Distance to airport (km)'],
             ['key' => 'metar.show_popup', 'value' => '1', 'type' => 'boolean', 'group' => 'aviation', 'description' => 'Show METAR popup details'],
 
+            // ===== Marine data location =====
+            ['key' => 'marine.latitude', 'value' => '', 'type' => 'string', 'group' => 'marine', 'description' => 'Latitude for marine data (leave empty to use the station location)'],
+            ['key' => 'marine.longitude', 'value' => '', 'type' => 'string', 'group' => 'marine', 'description' => 'Longitude for marine data (leave empty to use the station location)'],
+
             // ===== Weather Alerts =====
             ['key' => 'alerts.enabled', 'value' => '1', 'type' => 'boolean', 'group' => 'alerts', 'description' => 'Enable weather alerts/warnings'],
             ['key' => 'alerts.source', 'value' => 'europe', 'type' => 'select', 'group' => 'alerts', 'description' => 'Alert data source', 'options' => 'europe:Meteoalarm (Europe),usa:NWS (USA),canada:Environment Canada,uk:Met Office (UK),australia:BOM (Australia)'],

--- a/resources/views/admin/settings/waves.blade.php
+++ b/resources/views/admin/settings/waves.blade.php
@@ -12,6 +12,8 @@
 
     $lat = round((float) Setting::latitude(), 4);
     $lon = round((float) Setting::longitude(), 4);
+    $marineLat = trim((string) (Setting::getValue('marine.latitude', '') ?? ''));
+    $marineLon = trim((string) (Setting::getValue('marine.longitude', '') ?? ''));
 @endphp
 
 <div class="space-y-6">
@@ -71,23 +73,32 @@
             </div>
         </div>
 
-        {{-- Location info --}}
+        {{-- Location --}}
         <div class="bg-gray-800/50 rounded-2xl p-6 border border-white/10 mb-6">
             <h2 class="font-semibold text-white mb-4">{{ __('Data location') }}</h2>
             <p class="text-sm text-gray-400 mb-4">
-                {{ __('Wave and sea temperature data is fetched for your station coordinates. To change the location, update your Station Info settings.') }}
+                {{ __('Marine data is fetched for your station coordinates. If your station is inland, set the nearest stretch of coast here instead. Leave both empty to use the station location.') }}
             </p>
             <div class="grid grid-cols-2 gap-4">
-                <div class="bg-gray-900/40 rounded-xl p-4">
-                    <div class="text-xs text-gray-500 uppercase tracking-wider">{{ __('Latitude') }}</div>
-                    <div class="text-white font-mono text-lg mt-1">{{ $lat }}°</div>
+                <div>
+                    <label for="marine_latitude" class="block text-xs text-gray-500 uppercase tracking-wider mb-2">{{ __('Latitude') }}</label>
+                    <input type="number" step="0.0001" min="-90" max="90"
+                           name="marine_latitude" id="marine_latitude"
+                           value="{{ $marineLat }}" placeholder="{{ $lat }}"
+                           class="w-full px-4 py-2 rounded-xl bg-gray-900/40 border border-white/10 text-white font-mono">
                 </div>
-                <div class="bg-gray-900/40 rounded-xl p-4">
-                    <div class="text-xs text-gray-500 uppercase tracking-wider">{{ __('Longitude') }}</div>
-                    <div class="text-white font-mono text-lg mt-1">{{ $lon }}°</div>
+                <div>
+                    <label for="marine_longitude" class="block text-xs text-gray-500 uppercase tracking-wider mb-2">{{ __('Longitude') }}</label>
+                    <input type="number" step="0.0001" min="-180" max="180"
+                           name="marine_longitude" id="marine_longitude"
+                           value="{{ $marineLon }}" placeholder="{{ $lon }}"
+                           class="w-full px-4 py-2 rounded-xl bg-gray-900/40 border border-white/10 text-white font-mono">
                 </div>
             </div>
             <p class="mt-3 text-xs text-gray-500">
+                {{ __('Applies to waves, sea temperature and the tide sources that look up a grid point rather than a named station.') }}
+            </p>
+            <p class="mt-2 text-xs text-gray-500">
                 {{ __('Note: Open-Meteo Marine covers oceans and large bodies of water. Data may not be available for inland locations far from coast.') }}
             </p>
         </div>

--- a/tests/Feature/Marine/MarineCoordinatesTest.php
+++ b/tests/Feature/Marine/MarineCoordinatesTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Marine;
+
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Marine APIs only return data for ocean grid cells. An inland station gets
+ * nothing back, and moving the station coordinates is not an option because
+ * everything else uses them. So the marine lookups get their own optional
+ * point, falling back to the station when unset.
+ */
+class MarineCoordinatesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function station(float $lat, float $lon): void
+    {
+        Setting::setValue('station.latitude', (string) $lat, 'float', 'station');
+        Setting::setValue('station.longitude', (string) $lon, 'float', 'station');
+    }
+
+    public function test_it_falls_back_to_the_station_when_unset(): void
+    {
+        $this->station(43.6626, 10.6373);
+
+        $this->assertSame(43.6626, Setting::marineLatitude());
+        $this->assertSame(10.6373, Setting::marineLongitude());
+    }
+
+    public function test_a_configured_coastal_point_is_used_instead(): void
+    {
+        $this->station(43.6626, 10.6373);   // inland Tuscany
+        Setting::setValue('marine.latitude', '43.5000', 'string', 'marine');
+        Setting::setValue('marine.longitude', '10.2500', 'string', 'marine');
+
+        $this->assertSame(43.5, Setting::marineLatitude());
+        $this->assertSame(10.25, Setting::marineLongitude());
+    }
+
+    public function test_a_blank_value_is_treated_as_unset(): void
+    {
+        $this->station(52.5, 4.7);
+        Setting::setValue('marine.latitude', '', 'string', 'marine');
+        Setting::setValue('marine.longitude', '', 'string', 'marine');
+
+        $this->assertSame(52.5, Setting::marineLatitude());
+        $this->assertSame(4.7, Setting::marineLongitude());
+    }
+
+    public function test_the_admin_page_offers_the_fields_and_saves_them(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $this->actingAs($admin)->get(route('admin.settings.group', 'waves'))
+            ->assertOk()
+            ->assertSee('marine_latitude', false)
+            ->assertSee('marine_longitude', false);
+
+        $this->actingAs($admin)
+            ->post(route('admin.settings.update', 'waves'), [
+                'waves_enabled' => '1',
+                'marine_latitude' => '43.5',
+                'marine_longitude' => '10.25',
+            ])->assertRedirect();
+
+        $this->assertSame(43.5, Setting::marineLatitude());
+    }
+
+    public function test_clearing_the_fields_returns_to_the_station(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $this->station(52.5, 4.7);
+        Setting::setValue('marine.latitude', '43.5', 'string', 'marine');
+
+        $this->actingAs($admin)
+            ->post(route('admin.settings.update', 'waves'), [
+                'waves_enabled' => '1',
+                'marine_latitude' => '',
+                'marine_longitude' => '',
+            ])->assertRedirect();
+
+        $this->assertSame(52.5, Setting::marineLatitude());
+    }
+}


### PR DESCRIPTION
`baldomax`'s proposal in #53. Their station is ~20km inland in Tuscany, so the marine APIs return nothing: no wave height, no sea temperature, no tides.

`marine.latitude` and `marine.longitude` are optional and empty by default, which means "use the station". Nothing changes for an install already near the coast.

## Two departures from the proposal

**It covers four services, not two.** The issue targeted the wave service and a comment added `OpenMeteoMarineSource`. Grepping for the pattern found two more that fail identically inland:

- `OpenMeteoWaveService` (waves and sea temperature)
- `OpenMeteoMarineSource` (tides)
- `MareaSource` (tides)
- `CopernicusMarineSource` (tides)

The other tide sources take a named station rather than coordinates, so they are untouched.

**Named `marine.*` rather than `waves.*`.** Since it steers tide lookups too, a setting called "waves" would mislead whoever reads it next. The fields still live on the waves settings page where the proposal put them, and the copy says what they cover.

## UI

The location block was read-only with a note saying to change Station Info, which as the reporter points out is not a real option. It is now two optional inputs, placeholdered with the station coordinates so the fallback is visible.

## Verification

437 tests, 1313 assertions. Five new: fallback when unset, a configured point being used, blank treated as unset, the admin page offering and saving the fields, and clearing them returning to the station.

## Note on merge order

This branch trips the test suite's memory ceiling. The suite was at 127M against PHP's 128M default; these five tests take it to 131M and it dies with an OOM on a default config. #70 raises the declared limit and should go in first, or immediately after.