### PR TITLE
Add a Europe option to the pressure map

### DIFF
--- a/resources/lang/en-gb.json
+++ b/resources/lang/en-gb.json
@@ -3288,6 +3288,7 @@
     "The AEMET integration allows querying daily and hourly weather forecasts for municipalities in Spain.": "The AEMET integration allows querying daily and hourly weather forecasts for municipalities in Spain.",
     "The Municipality Code is the 5-digit INE code (e.g. 28079 for Madrid, 08019 for Barcelona).": "The Municipality Code is the 5-digit INE code (e.g. 28079 for Madrid, 08019 for Barcelona).",
     "e.g. 28079": "e.g. 28079",
+    "Europe": "Europe",
     "Nearby earthquakes": "Nearby",
     "Show": "Show",
     "Worldwide": "Worldwide"

--- a/resources/lang/en-us.json
+++ b/resources/lang/en-us.json
@@ -3288,6 +3288,7 @@
     "The AEMET integration allows querying daily and hourly weather forecasts for municipalities in Spain.": "The AEMET integration allows querying daily and hourly weather forecasts for municipalities in Spain.",
     "The Municipality Code is the 5-digit INE code (e.g. 28079 for Madrid, 08019 for Barcelona).": "The Municipality Code is the 5-digit INE code (e.g. 28079 for Madrid, 08019 for Barcelona).",
     "e.g. 28079": "e.g. 28079",
+    "Europe": "Europe",
     "Nearby earthquakes": "Nearby",
     "Show": "Show",
     "Worldwide": "Worldwide"

--- a/resources/lang/it-it.json
+++ b/resources/lang/it-it.json
@@ -3886,6 +3886,7 @@
     "The AEMET integration allows querying daily and hourly weather forecasts for municipalities in Spain.": "L'integrazione AEMET consente di consultare le previsioni meteorologiche giornaliere e orarie per i comuni in Spagna.",
     "The Municipality Code is the 5-digit INE code (e.g. 28079 for Madrid, 08019 for Barcelona).": "Il codice comune è il codice INE a 5 cifre (es. 28079 per Madrid, 08019 per Barcellona).",
     "e.g. 28079": "es. 28079",
+    "Europe": "Europa",
     "Nearby earthquakes": "Vicino a te",
     "Show": "Mostra",
     "Worldwide": "Nel mondo"

--- a/resources/lang/nl-nl.json
+++ b/resources/lang/nl-nl.json
@@ -3234,6 +3234,7 @@
     "The AEMET integration allows querying daily and hourly weather forecasts for municipalities in Spain.": "De AEMET-integratie maakt het mogelijk om dagelijkse en uurlijkse weersverwachtingen op te vragen voor Spaanse gemeenten.",
     "The Municipality Code is the 5-digit INE code (e.g. 28079 for Madrid, 08019 for Barcelona).": "De gemeentecode is de 5-cijferige INE-code (bijv. 28079 voor Madrid, 08019 for Barcelona).",
     "e.g. 28079": "bijv. 28079",
+    "Europe": "Europa",
     "Nearby earthquakes": "In de buurt",
     "Show": "Toon",
     "Worldwide": "Wereldwijd"

--- a/resources/views/weather/pressure-map.blade.php
+++ b/resources/views/weather/pressure-map.blade.php
@@ -38,6 +38,11 @@
                         onclick="changeMap('us')">
                     {{ __('United States') }}
                 </button>
+                <button class="map-button text-sm px-3 py-2 rounded-lg border border-white/20 bg-white/10 hover:bg-white/20 transition"
+                        data-map="europe"
+                        onclick="changeMap('europe')">
+                    {{ __('Europe') }}
+                </button>
             </div>
         </div>
 
@@ -66,9 +71,12 @@
         const maps = {
             atlantic: 'https://ocean.weather.gov/A_sfc_full_ocean_color.png',
             pacific: 'https://ocean.weather.gov/P_sfc_full_ocean_color.png',
-            us: 'https://www.wpc.ncep.noaa.gov/sfc/ussatsfc.gif'
+            us: 'https://www.wpc.ncep.noaa.gov/sfc/ussatsfc.gif',
+            // DWD's surface analysis for central and western Europe. Note this
+            // chart is around 4.5MB, where the NOAA ones are under 200KB.
+            europe: 'https://www.dwd.de/DWD/wetter/wv_spez/hobbymet/wetterkarten/bwk_bodendruck_na_ana.png'
         };
-        const mapOrder = ['atlantic', 'us', 'pacific'];
+        const mapOrder = ['atlantic', 'us', 'pacific', 'europe'];
 
         let currentMap = @json($defaultMap ?? 'atlantic');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -347,11 +347,19 @@ $publicRoutes = function () {
         ]);
     })->name('lightning');
 
-    // Pressure Map Popup (default map by station location; ?map=atlantic|us|pacific overrides)
+    // Pressure Map Popup (default map by station location; ?map=atlantic|us|pacific|europe overrides)
     Route::get('/pressure-map', function () {
         $lon = \App\Models\Setting::longitude();
-        $allowed = ['atlantic', 'us', 'pacific'];
-        $defaultByLocation = ($lon >= -130 && $lon <= -65) ? 'us' : (($lon >= 130 || $lon <= -120) ? 'pacific' : 'atlantic');
+        $lat = \App\Models\Setting::latitude();
+        $allowed = ['atlantic', 'us', 'pacific', 'europe'];
+
+        // Checked after the US and Pacific bands so those are unchanged.
+        // Longitude alone is not enough here: Cape Town shares Europe's
+        // meridians, so the box needs latitude too.
+        $inEurope = $lat >= 34 && $lat <= 72 && $lon >= -25 && $lon <= 45;
+        $defaultByLocation = ($lon >= -130 && $lon <= -65) ? 'us'
+            : (($lon >= 130 || $lon <= -120) ? 'pacific'
+            : ($inEurope ? 'europe' : 'atlantic'));
         $queryMap = strtolower(request()->query('map', ''));
         $defaultMap = in_array($queryMap, $allowed) ? $queryMap : $defaultByLocation;
         return view('weather.pressure-map', ['defaultMap' => $defaultMap]);

--- a/tests/Feature/PressureMapDefaultTest.php
+++ b/tests/Feature/PressureMapDefaultTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The default map was chosen from longitude alone, with no Europe case, so
+ * every European station fell through to a mid-Atlantic ocean chart.
+ */
+class PressureMapDefaultTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function station(float $lat, float $lon): void
+    {
+        Setting::setValue('station.latitude', (string) $lat, 'float', 'station');
+        Setting::setValue('station.longitude', (string) $lon, 'float', 'station');
+    }
+
+    private function defaultMap(): string
+    {
+        $response = $this->get('/pressure-map');
+        $response->assertOk();
+
+        return $response->viewData('defaultMap');
+    }
+
+    public function test_a_european_station_gets_the_europe_map(): void
+    {
+        $this->station(52.5164, 4.7079);        // Netherlands
+        $this->assertSame('europe', $this->defaultMap());
+
+        $this->station(43.6626, 10.6373);       // Italy
+        $this->assertSame('europe', $this->defaultMap());
+    }
+
+    public function test_the_existing_buckets_are_unchanged(): void
+    {
+        $this->station(38.9, -77.0);            // Washington DC
+        $this->assertSame('us', $this->defaultMap());
+
+        $this->station(21.3, -157.8);           // Honolulu
+        $this->assertSame('pacific', $this->defaultMap());
+
+        $this->station(-23.5, -46.6);           // Sao Paulo, still Atlantic
+        $this->assertSame('atlantic', $this->defaultMap());
+    }
+
+    /** Same longitude as Europe but far south, so not the Europe chart. */
+    public function test_latitude_is_required_not_just_longitude(): void
+    {
+        $this->station(-33.9, 18.4);            // Cape Town
+        $this->assertSame('atlantic', $this->defaultMap());
+    }
+
+    public function test_the_query_parameter_still_overrides(): void
+    {
+        $this->station(38.9, -77.0);
+
+        $response = $this->get('/pressure-map?map=europe');
+        $response->assertOk();
+        $this->assertSame('europe', $response->viewData('defaultMap'));
+    }
+
+    public function test_an_unknown_map_falls_back_to_the_location_default(): void
+    {
+        $this->station(52.5164, 4.7079);
+
+        $response = $this->get('/pressure-map?map=' . urlencode('../etc'));
+        $response->assertOk();
+        $this->assertSame('europe', $response->viewData('defaultMap'));
+    }
+}


### PR DESCRIPTION
`baldomax`'s proposal in #58. The page offered Atlantic, Pacific and US charts, all NOAA products aimed at US aviation and maritime forecasting, and the default was chosen from longitude alone with no Europe case. Every European station fell through to a mid-Atlantic ocean chart.

Adds DWD's European surface analysis as a fourth option, plus a Europe bucket checked after the existing US and Pacific bands so those are unchanged.

## The bounding box needs latitude, not just longitude

Worth calling out because it is easy to get wrong: Cape Town is at 18°E, inside Europe's meridians. A longitude-only check hands it a European surface chart. The proposal's box already included latitude; there is now a test pinning it (`test_latitude_is_required_not_just_longitude`) so it does not get simplified away later.

Verified the existing buckets still resolve: Washington DC to `us`, Honolulu to `pacific`, São Paulo to `atlantic`. `?map=` still overrides, and an unrecognised value falls back to the location default rather than erroring.

## One thing to decide before merging

I checked the DWD URL rather than assuming it works. It does, but it is heavy:

| map | size |
|---|---|
| Atlantic (NOAA) | 155 KB |
| US (NOAA) | 197 KB |
| **Europe (DWD)** | **4.6 MB** at 4389×3114 |

About 30× the others, hotlinked the same way. That is a real cost for exactly the users this feature is for, and on mobile it is noticeable.

I left it as-is because the fixes are bigger than the feature: proxy and downscale through the existing tile-proxy pattern, or lazy-load it. Happy to do either, but it should be your call rather than something bundled into an enhancement.

The reporter also noted DWD publish no SLA for that URL. The same is true of the NOAA URLs already in use, and the page already falls back through `mapOrder` on an image error, so a dead URL degrades rather than breaks.

## Verification

437 tests, 1316 assertions. Five new covering the Europe default, the unchanged buckets, the latitude requirement, the query override and an unrecognised value.

`Europe` added to `en-us`, `en-gb`, `it-it` (`Europa`) and `nl-nl` (`Europa`); the other 14 locales fall back to English.