### PR TITLE
Serve the pressure charts through the app instead of hotlinking them

### DIFF
--- a/app/Http/Controllers/Weather/PressureMapImageController.php
+++ b/app/Http/Controllers/Weather/PressureMapImageController.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Weather;
+
+use App\Http\Controllers\Controller;
+use App\Support\PressureMapRegistry;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
+use Intervention\Image\ImageManager;
+
+/**
+ * Serves the surface pressure charts through this app instead of hotlinking.
+ *
+ * DWD's European analysis is a 4.6MB scan at 4389x3114, around thirty times
+ * the NOAA charts, and every visitor was fetching it from DWD. Downscaled once
+ * and cached on disk, so the upstream sees one request per refresh window and
+ * the browser gets something proportionate to the space it is drawn in.
+ */
+class PressureMapImageController extends Controller
+{
+    /** Charts refresh a few times a day upstream. */
+    private const CACHE_TTL = 1800;
+
+    /** Wide enough for the isobar labels to stay readable when zoomed. */
+    private const MAX_WIDTH = 1600;
+
+    public function show(string $map): Response
+    {
+        if (!PressureMapRegistry::exists($map)) {
+            abort(404);
+        }
+
+        $path = "pressure-maps/{$map}.img";
+
+        if (Storage::disk('local')->exists($path)) {
+            $age = now()->timestamp - Storage::disk('local')->lastModified($path);
+            if ($age < self::CACHE_TTL) {
+                return $this->imageResponse(Storage::disk('local')->get($path));
+            }
+        }
+
+        // The URL comes from the registry, never from the request.
+        $url = (string) PressureMapRegistry::urlFor($map);
+
+        try {
+            $upstream = Http::timeout(20)->accept('image/*')->get($url);
+            $contentType = strtolower((string) $upstream->header('Content-Type', ''));
+
+            if ($upstream->successful() && str_contains($contentType, 'image/') && $upstream->body() !== '') {
+                $body = $this->shrink($upstream->body());
+                Storage::disk('local')->put($path, $body);
+
+                return $this->imageResponse($body);
+            }
+
+            Log::warning('Pressure map upstream failed', [
+                'map' => $map,
+                'status' => $upstream->status(),
+                'content_type' => $contentType,
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('Pressure map upstream exception', ['map' => $map, 'error' => $e->getMessage()]);
+        }
+
+        // Prefer a stale copy over nothing: these charts stay useful for hours.
+        if (Storage::disk('local')->exists($path)) {
+            return $this->imageResponse(Storage::disk('local')->get($path), true);
+        }
+
+        return response('Pressure map unavailable', 502);
+    }
+
+    /**
+     * Shrink anything wider than MAX_WIDTH and re-encode.
+     *
+     * Format is whichever the runtime can produce, best first. These charts are
+     * scans, so PNG stays large where a lossy format does not: the DWD chart at
+     * 1600px is 0.27MB as WebP, 0.39MB as JPEG and 1.43MB as PNG, from 4.39MB.
+     *
+     * WebP needs GD built --with-webp, which the shipped Dockerfile does not
+     * currently pass, so JPEG is the realistic outcome in the container. An
+     * image returned unchanged is a size cost, never a broken page.
+     */
+    private function shrink(string $binary): string
+    {
+        $manager = $this->imageManager();
+
+        if ($manager === null) {
+            return $binary;
+        }
+
+        try {
+            $image = $manager->read($binary);
+
+            if ($image->width() > self::MAX_WIDTH) {
+                $image = $image->scaleDown(width: self::MAX_WIDTH);
+            }
+
+            if (function_exists('imagewebp')) {
+                return (string) $image->toWebp(90);
+            }
+
+            if (function_exists('imagejpeg')) {
+                return (string) $image->toJpeg(90);
+            }
+
+            return (string) $image->toPng();
+        } catch (\Throwable $e) {
+            Log::warning('Pressure map re-encode failed, serving original', ['error' => $e->getMessage()]);
+
+            return $binary;
+        }
+    }
+
+    private function imageManager(): ?ImageManager
+    {
+        if (extension_loaded('imagick')) {
+            return new ImageManager(new ImagickDriver());
+        }
+
+        if (extension_loaded('gd')) {
+            return new ImageManager(new GdDriver());
+        }
+
+        return null;
+    }
+
+    private function imageResponse(string $body, bool $stale = false): Response
+    {
+        $mime = getimagesizefromstring($body)['mime'] ?? 'image/png';
+
+        return response($body, 200)
+            ->header('Content-Type', $mime)
+            ->header('Cache-Control', 'public, max-age=' . self::CACHE_TTL)
+            ->header('X-Pressure-Map-Cache', $stale ? 'stale' : 'fresh');
+    }
+}

--- a/app/Support/PressureMapRegistry.php
+++ b/app/Support/PressureMapRegistry.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * The surface pressure charts offered on /pressure-map.
+ *
+ * Held server side rather than in the page so the proxy can be keyed by name.
+ * A caller picks a chart, never a URL, so this cannot be turned into an open
+ * image proxy.
+ */
+class PressureMapRegistry
+{
+    /** @return array<string, array{url: string, label: string}> */
+    public static function all(): array
+    {
+        return [
+            'atlantic' => [
+                'url' => 'https://ocean.weather.gov/A_sfc_full_ocean_color.png',
+                'label' => 'Atlantic Ocean',
+            ],
+            'pacific' => [
+                'url' => 'https://ocean.weather.gov/P_sfc_full_ocean_color.png',
+                'label' => 'Pacific Ocean',
+            ],
+            'us' => [
+                'url' => 'https://www.wpc.ncep.noaa.gov/sfc/ussatsfc.gif',
+                'label' => 'United States',
+            ],
+            'europe' => [
+                'url' => 'https://www.dwd.de/DWD/wetter/wv_spez/hobbymet/wetterkarten/bwk_bodendruck_na_ana.png',
+                'label' => 'Europe',
+            ],
+        ];
+    }
+
+    public static function exists(string $map): bool
+    {
+        return array_key_exists($map, self::all());
+    }
+
+    public static function urlFor(string $map): ?string
+    {
+        return self::all()[$map]['url'] ?? null;
+    }
+
+    /** @return list<string> */
+    public static function names(): array
+    {
+        return array_keys(self::all());
+    }
+}

--- a/resources/views/weather/pressure-map.blade.php
+++ b/resources/views/weather/pressure-map.blade.php
@@ -68,15 +68,10 @@
 </div>
 
 <script>
-        const maps = {
-            atlantic: 'https://ocean.weather.gov/A_sfc_full_ocean_color.png',
-            pacific: 'https://ocean.weather.gov/P_sfc_full_ocean_color.png',
-            us: 'https://www.wpc.ncep.noaa.gov/sfc/ussatsfc.gif',
-            // DWD's surface analysis for central and western Europe. Note this
-            // chart is around 4.5MB, where the NOAA ones are under 200KB.
-            europe: 'https://www.dwd.de/DWD/wetter/wv_spez/hobbymet/wetterkarten/bwk_bodendruck_na_ana.png'
-        };
-        const mapOrder = ['atlantic', 'us', 'pacific', 'europe'];
+        // Served through this app rather than hotlinked: the charts are fetched
+        // once per refresh window, downscaled, and cached on disk.
+        const maps = @json($mapUrls);
+        const mapOrder = @json($mapOrder);
 
         let currentMap = @json($defaultMap ?? 'atlantic');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -351,7 +351,7 @@ $publicRoutes = function () {
     Route::get('/pressure-map', function () {
         $lon = \App\Models\Setting::longitude();
         $lat = \App\Models\Setting::latitude();
-        $allowed = ['atlantic', 'us', 'pacific', 'europe'];
+        $allowed = \App\Support\PressureMapRegistry::names();
 
         // Checked after the US and Pacific bands so those are unchanged.
         // Longitude alone is not enough here: Cape Town shares Europe's
@@ -362,8 +362,22 @@ $publicRoutes = function () {
             : ($inEurope ? 'europe' : 'atlantic'));
         $queryMap = strtolower(request()->query('map', ''));
         $defaultMap = in_array($queryMap, $allowed) ? $queryMap : $defaultByLocation;
-        return view('weather.pressure-map', ['defaultMap' => $defaultMap]);
+        $mapUrls = [];
+        foreach (\App\Support\PressureMapRegistry::names() as $name) {
+            $mapUrls[$name] = route('weather.pressure-map.image', ['map' => $name]);
+        }
+
+        return view('weather.pressure-map', [
+            'defaultMap' => $defaultMap,
+            'mapUrls' => $mapUrls,
+            'mapOrder' => \App\Support\PressureMapRegistry::names(),
+        ]);
     })->name('weather.pressure-map');
+
+    // Charts are proxied and downscaled rather than hotlinked. Keyed by name,
+    // so no caller can point this at an arbitrary host.
+    Route::get('/pressure-map/image/{map}', [\App\Http\Controllers\Weather\PressureMapImageController::class, 'show'])
+        ->name('weather.pressure-map.image');
 
     // Community Stations Map
     Route::get('/community-stations', [\App\Http\Controllers\CommunityStationsController::class, 'index'])->name('weather.community-stations');

--- a/tests/Feature/PressureMapImageProxyTest.php
+++ b/tests/Feature/PressureMapImageProxyTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * The charts were hotlinked straight from NOAA and DWD. DWD's European surface
+ * analysis is a 4.6MB scan at 4389x3114, roughly thirty times the NOAA images,
+ * and every visitor fetched it from DWD directly.
+ */
+class PressureMapImageProxyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** A real 40x30 PNG, big enough to prove downscaling happened. */
+    private function wideImage(): string
+    {
+        $im = imagecreatetruecolor(2400, 1600);
+        imagefill($im, 0, 0, imagecolorallocate($im, 10, 20, 30));
+        ob_start();
+        imagepng($im);
+        imagedestroy($im);
+
+        return (string) ob_get_clean();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('local');
+    }
+
+    public function test_it_serves_a_known_map(): void
+    {
+        Http::fake(['*' => Http::response($this->wideImage(), 200, ['Content-Type' => 'image/png'])]);
+
+        $response = $this->get('/pressure-map/image/europe');
+
+        $response->assertOk();
+        $this->assertStringStartsWith('image/', (string) $response->headers->get('Content-Type'));
+    }
+
+    public function test_it_downscales_an_oversized_chart(): void
+    {
+        Http::fake(['*' => Http::response($this->wideImage(), 200, ['Content-Type' => 'image/png'])]);
+
+        $bytes = $this->get('/pressure-map/image/europe')->getContent();
+        $size = getimagesizefromstring($bytes);
+
+        $this->assertNotFalse($size);
+        $this->assertLessThanOrEqual(1600, $size[0], 'The chart should be scaled down before it reaches the browser.');
+        $this->assertLessThan(strlen($this->wideImage()), strlen($bytes));
+    }
+
+    public function test_an_unknown_map_is_refused(): void
+    {
+        Http::fake();
+
+        $this->get('/pressure-map/image/not-a-map')->assertStatus(404);
+        Http::assertNothingSent();
+    }
+
+    /** Keyed by map name, so it cannot be pointed at an arbitrary host. */
+    public function test_it_takes_no_url_from_the_caller(): void
+    {
+        Http::fake(['*' => Http::response($this->wideImage(), 200, ['Content-Type' => 'image/png'])]);
+
+        $this->get('/pressure-map/image/europe?url=' . urlencode('https://example.test/evil.png'))->assertOk();
+
+        Http::assertSent(fn ($request) => !str_contains($request->url(), 'example.test'));
+    }
+
+    public function test_a_second_request_is_served_from_disk(): void
+    {
+        Http::fake(['*' => Http::response($this->wideImage(), 200, ['Content-Type' => 'image/png'])]);
+
+        $this->get('/pressure-map/image/europe')->assertOk();
+        $this->get('/pressure-map/image/europe')->assertOk();
+
+        Http::assertSentCount(1);
+    }
+
+    public function test_an_upstream_failure_does_not_500(): void
+    {
+        Http::fake(['*' => Http::response('nope', 503)]);
+
+        $this->get('/pressure-map/image/atlantic')->assertStatus(502);
+    }
+}


### PR DESCRIPTION
Follow-up to #72, which added the Europe chart and flagged its weight.

## The problem

DWD's European surface analysis is a **4.39 MB scan at 4389×3114**, against 155 KB and 197 KB for the NOAA charts. Every visitor fetched it from DWD directly, and for a European station it is the default map, so it loaded on arrival.

I checked whether a smaller official chart exists before building this. The only other working DWD pressure chart I found is `ezmw_ht500pboden_na_072168.png` at 882 KB, but that is a medium-range forecast rather than a surface analysis, so it is not a substitute. KNMI's chart URLs return 403.

## What this does

Fetches once per refresh window, scales to 1600px, caches on disk. Measured against the live chart:

| | size | saving |
|---|---|---|
| upstream | 4.39 MB | — |
| PNG @1600 | 1.43 MB | 67% |
| JPEG q90 @1600 | 0.39 MB | 91% |
| WebP q90 @1600 | 0.27 MB | 94% |

## Format is picked from what the runtime has, not from my machine

WebP encodes best, and works here. But the Dockerfile configures GD with `--with-freetype --with-jpeg` and **not** `--with-webp`, so it is probably unavailable in the shipped container. The controller tries WebP, then JPEG, then PNG, so the container realistically lands on **JPEG at 0.39 MB**, still a 91% reduction. With no image extension at all the original passes through unchanged: a size cost, never a broken page.

Adding `libwebp-dev` and `--with-webp` to the Dockerfile would get the remaining 30%. I left it out deliberately: I cannot build the image here to verify it, and a failed image build is worse than a larger chart. Worth a separate change if you want it.

The lossy formats are a real if minor tradeoff on a chart with text and thin isobars, which is why q90 rather than the usual 85.

## Also

Chart URLs move from the page JavaScript into `PressureMapRegistry`. That is what lets the proxy be keyed by map name rather than accepting a URL from the caller, so it cannot be turned into an open image proxy, and there is a test asserting a `?url=` parameter is ignored. It also keeps the list in one place; the route's `$allowed` now comes from the registry rather than a second hardcoded array.

A stale cached copy is served if upstream fails, since these charts stay useful for hours. Upstream sees one request per refresh window instead of one per visitor.

## Verification

443 tests, 1330 assertions. Six new: serving a known map, downscaling an oversized chart, refusing an unknown map, ignoring a caller-supplied URL, the second request coming from disk, and an upstream failure returning 502 rather than 500.