### PR TITLE
Let the phone header wrap instead of cutting buttons off

### DIFF
--- a/resources/views/weather/dashboard.blade.php
+++ b/resources/views/weather/dashboard.blade.php
@@ -1058,8 +1058,8 @@
             <!-- Mobile: Two rows -->
             <div class="flex flex-col gap-2 sm:hidden">
                 <!-- Row 1: Logo and controls -->
-                <div class="flex items-center justify-between">
-                    <div class="flex items-center gap-3">
+                <div class="flex flex-wrap items-center justify-between gap-y-2">
+                    <div class="flex items-center gap-3 min-w-0">
                         <div class="w-8 h-8 bg-gradient-to-br from-blue-500 to-cyan-400 rounded-lg flex items-center justify-center shadow-lg shadow-blue-500/30">
                             <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z"/>
@@ -1070,7 +1070,7 @@
                             <p class="text-xs text-gray-400">{{ \App\Models\Setting::stationLocation() }}</p>
                         </div>
                     </div>
-                    <div class="flex items-center gap-2">
+                    <div class="flex items-center gap-2 shrink-0 ml-auto">
                         @if(($siteTheme ?? 'fx') !== 'flat')
                         <!-- FX button: visible to all visitors (toggles rain/snow/fog etc.; preference saved in localStorage) -->
                         <button @click="toggleBackgroundEffects()" :class="backgroundEffectsEnabled ? 'bg-emerald-600 hover:bg-emerald-500' : 'bg-gray-600 hover:bg-gray-500'" class="px-3 py-1 text-xs rounded transition-colors flex items-center gap-1" :title="backgroundEffectsEnabled ? '{{ __('Disable background effects') }}' : '{{ __('Enable background effects') }}'">

--- a/resources/views/weather/layout.blade.php
+++ b/resources/views/weather/layout.blade.php
@@ -218,8 +218,8 @@
             <!-- Mobile: Two rows -->
             <div class="flex flex-col gap-2 lg:hidden">
                 <!-- Row 1: Logo and controls -->
-                <div class="flex items-center justify-between">
-                    <a href="{{ route('home') }}" class="flex items-center gap-3">
+                <div class="flex flex-wrap items-center justify-between gap-y-2">
+                    <a href="{{ route('home') }}" class="flex items-center gap-3 min-w-0">
                         <div class="w-8 h-8 bg-gradient-to-br from-blue-500 to-cyan-400 rounded-lg flex items-center justify-center shadow-lg shadow-blue-500/30">
                             <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z"/>
@@ -230,7 +230,7 @@
                             <p class="text-xs text-gray-400">{{ \App\Models\Setting::stationLocation() }}</p>
                         </div>
                     </a>
-                    <div class="flex items-center gap-2">
+                    <div class="flex items-center gap-2 shrink-0 ml-auto">
                         @auth
                             @if(auth()->user()->is_admin)
                                 @if(($siteTheme ?? 'fx') !== 'flat')


### PR DESCRIPTION
Fixes #78.

## What was wrong

On a 412px phone the header row has 372px to work with. Logged in as an admin in Spanish, the parts need more than that:

| part | width |
|---|---|
| station name | 240px |
| FX, Editar, Administrador, ES, units | 318px |
| **total** | **558px in a 372px space** |

Nothing could give way. The row was not allowed to wrap, and neither side was allowed to shrink, so the row simply ran off the edge. The language button was half cut and the units button sat entirely off screen.

Measured before the fix:

```
row width:        372
controls:         136 .. 453     (65px past the row, 41px past the screen)
cut off:          ES, units
station name:     squeezed onto 3 lines
header height:    154px
```

## The fix

Six class changes in two files. The row can wrap, the name can shrink, and the buttons stay together as a group.

The station name keeps its own line and the buttons drop to a line of their own once they stop fitting. Because the name no longer wraps onto three lines, **the header ends up 22px shorter than before, not taller**.

## Why not icons

@centauri suggested icon-only buttons, so I measured that too. It shrinks the buttons from 318px to 194px, which is real, but 194 + 240 is still more than 372, so the station name would still be squeezed onto three lines. It also turns "Administrador" into a cog that not everyone will recognise. Wrapping keeps the words in every language and cannot break again however long a name or a translation gets.

## Checked

The buttons only render for a logged-in admin, so I rendered the real page as one and measured it in a browser at Pixel 7 size. The reproduction matched the screenshot in the issue exactly.

| case | result |
|---|---|
| admin, phone, Spanish, dashboard | all 5 buttons visible, name on one line, header 132px |
| admin, phone, other pages (layout header) | all 4 buttons visible, nothing off screen |
| visitor, not logged in | unchanged, 98px before and after |
| desktop | unchanged, the phone block is not displayed at all |

453 tests, 1404 assertions.

Thanks @victormac3000 for the clear steps and the screenshot. That is what made this quick to pin down.