### PR TITLE
Stop the endless run of empty history days, and explain robots.txt

### DIFF
--- a/app/Http/Controllers/HistoryController.php
+++ b/app/Http/Controllers/HistoryController.php
@@ -8,6 +8,7 @@ use App\Models\WeatherReading;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 class HistoryController extends Controller
@@ -147,6 +148,23 @@ class HistoryController extends Controller
     /**
      * Show specific day detail
      */
+    /**
+     * The oldest day with a reading, or null when nothing has been recorded
+     * yet. Cached because it bounds every day page and never moves backwards.
+     */
+    private function firstRecordedDay(): ?Carbon
+    {
+        $first = Cache::remember('history.first_recorded_day', now()->addHours(12), function () {
+            return WeatherReading::min('recorded_at');
+        });
+
+        if (!$first) {
+            return null;
+        }
+
+        return Carbon::parse($first)->startOfDay();
+    }
+
     public function day(Request $request, string $date)
     {
         // Strict date parsing (prevents weird inputs + keeps routes predictable)
@@ -156,7 +174,17 @@ class HistoryController extends Controller
             abort(404);
         }
         $dateString = $dateObj->format('Y-m-d');
-        
+
+        // Outside the recorded period there is nothing to show, and the day
+        // page used to link one day further back forever. A crawler could walk
+        // from the first real day back to the year 1800, in every language.
+        $firstRecordedDay = $this->firstRecordedDay();
+
+        if ($dateObj->isAfter(now()->startOfDay())
+            || ($firstRecordedDay !== null && $dateObj->lt($firstRecordedDay))) {
+            abort(404);
+        }
+
         $summary = DailySummary::whereDate('date', $dateString)->first();
 
         // IMPORTANT: do NOT eager-load all readings here (can be thousands of rows).
@@ -458,6 +486,7 @@ class HistoryController extends Controller
         ];
 
         return view('weather.day', compact(
+            'firstRecordedDay',
             'summary',
             'date',
             'dayChart',

--- a/resources/views/weather/day.blade.php
+++ b/resources/views/weather/day.blade.php
@@ -1,6 +1,9 @@
 @extends('weather.layout')
 @section('og_image', isset($date) ? route('og.history', ['date' => $date]) : route('og.home'))
 @php
+    // A day inside the record with no readings is a real URL, but there is
+    // nothing on it worth indexing.
+    $seoNoIndex = ($readingsCount ?? 0) === 0;
     $activeUnits = $activeUnits ?? 'metric';
     $activeLocale = $activeLocale ?? app()->getLocale();
     $locale = str_replace('-', '_', $activeLocale);
@@ -27,11 +30,17 @@
             @php
                 $prevDay = $dateObj->copy()->subDay();
                 $nextDay = $dateObj->copy()->addDay();
+                // Stop at the first recorded day. Linking past it produced an
+                // endless run of empty pages for anything following links.
+                $hasPrevDay = !isset($firstRecordedDay) || $firstRecordedDay === null
+                    || $prevDay->gte($firstRecordedDay);
             @endphp
-            <a href="{{ route('history.day', $prevDay->format('Y-m-d')) }}" 
-               class="px-4 py-2 bg-white/10 hover:bg-white/20 rounded-lg transition">
-                ← {{ $prevDay->locale($locale)->translatedFormat('j M') }}
-            </a>
+            @if($hasPrevDay)
+                <a href="{{ route('history.day', $prevDay->format('Y-m-d')) }}"
+                   class="px-4 py-2 bg-white/10 hover:bg-white/20 rounded-lg transition">
+                    ← {{ $prevDay->locale($locale)->translatedFormat('j M') }}
+                </a>
+            @endif
             @if($nextDay->lte(now()))
                 <a href="{{ route('history.day', $nextDay->format('Y-m-d')) }}" 
                    class="px-4 py-2 bg-white/10 hover:bg-white/20 rounded-lg transition">

--- a/resources/views/weather/layout.blade.php
+++ b/resources/views/weather/layout.blade.php
@@ -83,6 +83,12 @@
     @if(is_string($seoSiteKeywords) && trim($seoSiteKeywords) !== '')
         <meta name="keywords" content="{{ trim($seoSiteKeywords) }}">
     @endif
+    @isset($seoNoIndex)
+        @if($seoNoIndex)
+            {{-- Real URL, but nothing worth putting in an index. --}}
+            <meta name="robots" content="noindex,follow">
+        @endif
+    @endisset
     <link rel="canonical" href="{{ $seoCanonical }}">
     @foreach($localeOptions as $code => $meta)
         <link rel="alternate" hreflang="{{ $code }}" href="{{ localeCanonicalUrl($code) }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,92 @@ Route::get('/manifest.json', function () {
 
 /*
 |--------------------------------------------------------------------------
+| robots.txt
+|--------------------------------------------------------------------------
+| Served from here so the Sitemap line carries this install's own domain.
+| A real file at public/robots.txt is served by the web server instead, so
+| anyone who wants different rules can copy this output there and edit it.
+*/
+Route::get('/robots.txt', function () {
+    $sitemap = rtrim(url('/'), '/').'/sitemap.xml';
+
+    $body = <<<TXT
+# robots.txt for WeatherNode
+#
+# Lines beginning with # are notes for you. Crawlers ignore them.
+#
+# To change any of this: save this page as public/robots.txt in your
+# install and edit that copy. A file there replaces this default.
+
+User-agent: *
+Allow: /
+
+# Admin, sign in and account pages. Nothing here belongs in a search engine.
+Disallow: /admin
+Disallow: /login
+Disallow: /register
+Disallow: /password
+Disallow: /profile
+
+# The JSON API. Crawling it burns your bandwidth and indexes nothing a
+# person would search for. Page content is in the HTML already, so this
+# does not hide anything from Google.
+Disallow: /api/
+
+# The unit switch links (?units=imperial and so on) show the same page
+# in different units. Without this line every page gets fetched four
+# extra times for no new content.
+Disallow: /*?units=
+
+# Bing honours Crawl-delay. This asks for one page every 10 seconds.
+# Raise the number if bots are still using too much of your server.
+User-agent: bingbot
+Crawl-delay: 10
+
+# EXAMPLE, off by default. Daily archive pages are the biggest part of a
+# weather site and people do search for "weather on 12 February". Remove
+# the # marks only if you would rather they were never in search results.
+# User-agent: *
+# Disallow: /history/
+
+# EXAMPLE, off by default. Shut out one crawler completely. Replace the
+# name with the one you see in Admin > Analytics.
+# User-agent: BadBot
+# Disallow: /
+
+# EXAMPLE, off by default. Let one crawler in and keep the rest out.
+# User-agent: Googlebot
+# Allow: /
+# User-agent: *
+# Disallow: /
+
+Sitemap: {$sitemap}
+
+# --------------------------------------------------------------------
+# Still too much bot traffic?
+#
+# Bing: bing.com/webmasters, then Settings > Crawl Control. You can set
+#   the pages per hour, hour by hour. It takes effect faster than the
+#   Crawl-delay above and is the better tool of the two.
+#
+# Google: Googlebot ignores Crawl-delay, and the old crawl rate setting
+#   in Search Console was withdrawn. Google now decides the rate itself
+#   and slows down when a site answers with 429 or 503. If Googlebot is
+#   genuinely overloading you, report it at
+#   search.google.com/search-console and pick the crawl rate form.
+#
+# Neither one is instant. A change here can take hours or days to show
+# up, because crawlers re-read this file on their own schedule.
+# --------------------------------------------------------------------
+TXT;
+
+    return response($body, 200, [
+        'Content-Type' => 'text/plain; charset=UTF-8',
+    ]);
+})->name('robots');
+
+/*
+|--------------------------------------------------------------------------
 | Sitemap XML
 |--------------------------------------------------------------------------
 */
@@ -194,32 +280,6 @@ Route::get('/sitemap.xml', function () {
         'Content-Type' => 'application/xml; charset=UTF-8',
     ]);
 })->name('sitemap');
-
-/*
-|--------------------------------------------------------------------------
-| Robots.txt (dynamic)
-|--------------------------------------------------------------------------
-*/
-Route::get('/robots.txt', function () {
-    $sitemapUrl = url('/sitemap.xml');
-
-    $content = "User-agent: *\n";
-    $content .= "Allow: /\n";
-    $content .= "\n";
-    $content .= "# Disallow admin and auth pages\n";
-    $content .= "Disallow: /admin\n";
-    $content .= "Disallow: /login\n";
-    $content .= "Disallow: /register\n";
-    $content .= "Disallow: /password\n";
-    $content .= "Disallow: /profile\n";
-    $content .= "\n";
-    $content .= "# Sitemap\n";
-    $content .= "Sitemap: {$sitemapUrl}\n";
-
-    return response($content, 200, [
-        'Content-Type' => 'text/plain; charset=UTF-8',
-    ]);
-})->name('robots');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Feature/HistoryDayCrawlBoundsTest.php
+++ b/tests/Feature/HistoryDayCrawlBoundsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\WeatherReading;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The day page linked to the day before it with no lower bound, so a crawler
+ * could walk back from 2020 to the year 1800 and never finish. Every one of
+ * those empty days returned 200 and asked to be indexed.
+ */
+class HistoryDayCrawlBoundsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function reading(string $date): void
+    {
+        WeatherReading::create([
+            'recorded_at' => Carbon::parse($date.' 12:00:00'),
+            'temperature' => 15.0,
+        ]);
+    }
+
+    public function test_a_date_before_the_first_reading_is_gone(): void
+    {
+        $this->reading('2026-08-10');
+
+        $this->get('/history/2026-08-09')->assertNotFound();
+        $this->get('/history/1800-01-01')->assertNotFound();
+    }
+
+    public function test_a_date_in_the_future_is_gone(): void
+    {
+        $this->reading('2026-08-10');
+
+        $this->get('/history/'.now()->addDay()->format('Y-m-d'))->assertNotFound();
+    }
+
+    public function test_the_first_day_does_not_link_further_back(): void
+    {
+        $this->reading('2026-08-10');
+        $this->reading('2026-08-11');
+
+        $this->get('/history/2026-08-10')
+            ->assertOk()
+            ->assertDontSee('/history/2026-08-09');
+    }
+
+    public function test_a_later_day_still_links_back(): void
+    {
+        $this->reading('2026-08-10');
+        $this->reading('2026-08-11');
+
+        $this->get('/history/2026-08-11')
+            ->assertOk()
+            ->assertSee('/history/2026-08-10');
+    }
+
+    public function test_a_day_with_data_is_indexable(): void
+    {
+        $this->reading('2026-08-10');
+
+        $this->get('/history/2026-08-10')
+            ->assertOk()
+            ->assertDontSee('name="robots"', false);
+    }
+
+    /** A gap in the middle of the record is a real URL, but not one worth indexing. */
+    public function test_a_day_with_no_data_inside_the_range_is_noindex(): void
+    {
+        $this->reading('2026-08-10');
+        $this->reading('2026-08-14');
+
+        $this->get('/history/2026-08-12')
+            ->assertOk()
+            ->assertSee('name="robots" content="noindex,follow"', false);
+    }
+}

--- a/tests/Feature/RobotsTxtTest.php
+++ b/tests/Feature/RobotsTxtTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/** The app shipped no robots.txt, so every install had to write its own. */
+class RobotsTxtTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_is_served_as_plain_text(): void
+    {
+        $this->get('/robots.txt')
+            ->assertOk()
+            ->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+    }
+
+    public function test_it_points_at_this_installs_own_sitemap(): void
+    {
+        $this->get('/robots.txt')
+            ->assertSee('Sitemap: '.rtrim(url('/'), '/').'/sitemap.xml');
+    }
+
+    public function test_it_keeps_crawlers_out_of_the_admin_and_the_api(): void
+    {
+        $response = $this->get('/robots.txt');
+
+        foreach (['Disallow: /admin', 'Disallow: /api/', 'Disallow: /*?units='] as $rule) {
+            $response->assertSee($rule);
+        }
+    }
+
+    /** The pages people actually search for have to stay crawlable. */
+    public function test_it_does_not_block_the_weather_pages(): void
+    {
+        $body = $this->get('/robots.txt')->getContent();
+
+        foreach (["\nDisallow: /history/", "\nDisallow: /forecast", "\nDisallow: /\n"] as $rule) {
+            $this->assertStringNotContainsString($rule, $body);
+        }
+    }
+
+    public function test_it_explains_itself_so_it_can_be_edited(): void
+    {
+        $body = $this->get('/robots.txt')->getContent();
+
+        $this->assertStringContainsString('public/robots.txt', $body);
+        $this->assertGreaterThan(10, substr_count($body, "\n#"), 'expected comments explaining each rule');
+    }
+}


### PR DESCRIPTION
Refs #55.

## What was actually wrong

#55 blamed the missing robots.txt. The app does generate one from a route, so that part of the report was off, but the traffic it measured was real. The cause is a link, not a missing file.

The day page linked to the day before it with nothing to stop it. On the live site, before this change:

```
/history/2026-08-20   200
/history/2019-01-01   200      data starts in 2020
/history/1990-01-01   200
/history/1800-01-01   200      and its back button points at 1799-12-31
```

Every one of those returned a full 87KB page with a canonical tag asking to be indexed. Multiply by 18 languages and 4 `?units=` variants and one real day is 90 URLs, on a date axis with no end. Anything following links could walk backwards for ever, which is what Bing did: 63,769 requests in a day, 99% of all traffic on that install.

## Changes

**Bound the day page.** A date after today, or before the first reading, is a 404. The back link stops at the first day with data. Days with data are untouched, they stay fully indexable, because those are the pages people search for.

**Empty days ask not to be indexed.** A day inside the record with no readings (station offline, a gap) renders normally but sends `noindex,follow`. It still works for a visitor, it just stops competing with real days.

**robots.txt now says something.** It was:

```
User-agent: *
Allow: /
Disallow: /admin  /login  /register  /password  /profile
Sitemap: ...
```

It now also blocks `/api/` and `Disallow: /*?units=`, carries `Crawl-delay: 10` for bingbot, and explains every line so an owner can adapt it. Three examples ship commented out: block the history archive, block one crawler, allow only Google. The footer covers Bing Webmaster Tools crawl control, and the fact that Googlebot ignores `Crawl-delay` and that Search Console's crawl rate setting was withdrawn.

Blocking `/api/` is safe here: the pages are server rendered, 12 temperature values appear in the raw HTML of the home page, so a crawler sees the content without the API.

## Deliberately not done

Not blocking `/history/` in robots.txt, which #55 offered as an option. Daily archive pages are genuine long tail content, the kind of thing people search for by date. Bounding them is the fix, removing them from search is a loss. The example is in the file for anyone who disagrees.

## Tests

11 new, 472 total.

- dates before the first reading and after today are 404
- the first day does not render a back link, a later day does
- a day with data has no robots meta, an empty day inside the record does
- robots.txt is plain text, points at this install's own sitemap, blocks admin, api and the units duplicates
- robots.txt never blocks `/history/`, `/forecast`, or the whole site

## After merging

Crawlers will not notice at once. Bing has the old URLs queued and will work through them collecting 404s over days. Setting a crawl rate in Bing Webmaster Tools remains the fastest lever, and that is a setting on their site, not code.