### PR TITLE
Fix satellite panel width on /radar

### DIFF
--- a/resources/views/weather/radar.blade.php
+++ b/resources/views/weather/radar.blade.php
@@ -151,7 +151,7 @@
 
         <!-- Satellite -->
         @if($satelliteEnabled)
-        <div class="bg-weather-card rounded-2xl p-4 border border-white/10">
+        <div class="bg-weather-card rounded-2xl p-4 border border-white/10 md:col-span-2">
             @php
                 $yesterdayUtc = gmdate('Y-m-d', time() - 86400);
                 $satelliteProvider = \App\Models\Setting::getValue('satellite.provider', 'knmi');


### PR DESCRIPTION
The satellite card sat inside a 2-column grid without spanning both columns, so it rendered at half width even when Buienradar was hidden or the layout only had one other card. This adds `md:col-span-2` so it always takes the full row width