### PR TITLE
Build gd with its libraries again, and fail the build if they go missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,13 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     libpng-dev \
     libjpeg62-turbo-dev \
     libfreetype6-dev \
+    libwebp-dev \
     libonig-dev \
     libxml2-dev \
     libcurl4-openssl-dev \
     unzip \
     git \
     && apt-get install -y --only-upgrade libgnutls30 \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) curl \
     && docker-php-ext-install -j$(nproc) pdo_sqlite \
     && docker-php-ext-install -j$(nproc) pdo_mysql \
@@ -42,9 +42,21 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     && docker-php-ext-install -j$(nproc) xml \
     && docker-php-ext-install -j$(nproc) dom \
     && docker-php-ext-install -j$(nproc) zip \
-    && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-install -j$(nproc) bcmath \
+    # gd is configured immediately before it is installed, and nothing may run
+    # between the two. docker-php-ext-configure unpacks the PHP source and
+    # leaves a .docker-delete-me marker; every docker-php-ext-install deletes
+    # that source when it finishes. Any install in between therefore throws the
+    # configured gd away, and the later `install gd` rebuilds it with no flags
+    # at all: no FreeType (OG images 500), no JPEG, no WebP.
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+    && docker-php-ext-install -j$(nproc) gd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Fail the build rather than ship a gd that silently lost its libraries. A gd
+# without FreeType 500s on every OG image, and without JPEG or WebP the proxied
+# charts fall back to PNG at roughly four times the size.
+RUN php -r '$missing = array_filter(["FreeType Support", "JPEG Support", "PNG Support", "WebP Support"], fn ($k) => empty(gd_info()[$k])); if ($missing) { fwrite(STDERR, "gd built without: " . implode(", ", $missing) . PHP_EOL); exit(1); } echo "gd: freetype, jpeg, png and webp all present" . PHP_EOL;'
 
 # Composer
 ENV COMPOSER_ALLOW_SUPERUSER=1


### PR DESCRIPTION
Fixes #87. Fixes #74.

## What the published image actually contains

Checked inside `ghcr.io/centauri/weathernode:v2026.08.9` on aarch64, the same architecture as the Raspberry Pi in the report:

```
FreeType Support  false
JPEG Support      false
PNG Support       true
WebP Support      false

imageftbbox  MISSING
imagejpeg    MISSING
imagewebp    MISSING
```

So this is wider than the report. Every Docker user has a gd that can only do PNG.

## Why

`docker-php-ext-configure` unpacks the PHP source and, when it created that directory, leaves a `.docker-delete-me` marker. Every `docker-php-ext-install` ends with:

```sh
if [ -e /usr/src/php/.docker-delete-me ]; then
	docker-php-source delete
fi
```

The Dockerfile configured gd first and installed it nine lines later:

```dockerfile
&& docker-php-ext-configure gd --with-freetype --with-jpeg \
&& docker-php-ext-install -j$(nproc) curl \
...
&& docker-php-ext-install -j$(nproc) gd \
```

The `curl` install deleted the source, taking the configured gd with it. `install gd` then unpacked a fresh copy, found no Makefile, and ran `docker-php-ext-configure gd` with **no arguments**. The flags were never applied. It has been that way since the Dockerfile was written in v2026.05.0.

## What this broke

- **#87**: no FreeType, so Intervention's `FontProcessor` calls `imageftbbox()` and every OG image answers 500
- **#74**: no WebP. I filed that issue saying the Dockerfile needed `--with-webp` added. That was wrong, `--with-jpeg` was being lost too
- the pressure map proxy falls through WebP and JPEG to PNG, so Docker users fetch about 1.4MB per chart instead of 0.4MB

## The fix

Configure immediately before the install with nothing in between, and add webp:

```dockerfile
&& docker-php-ext-install -j$(nproc) bcmath \
&& docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
&& docker-php-ext-install -j$(nproc) gd \
```

Plus `libwebp-dev`, and a build step that fails if any of the four are missing. This shipped quietly for months; a build that answers loudly is worth one layer.

## Verified, not assumed

Same script run in both images, using the real Intervention code path from the report:

```
weathernode:v2026.08.9    FAILED: Call to undefined function Intervention\Image\Drivers\Gd\imageftbbox()
weathernode-gdtest:local  OK, drew text, 6083 bytes png
```

The rebuilt image reports FreeType, JPEG, PNG and WebP all true. The new guard was run against v2026.08.9 to confirm it catches the broken build:

```
gd built without: FreeType Support, JPEG Support, WebP Support
exit code: 1
```

472 tests still pass, though nothing in the PHP suite can see a Dockerfile.

## After merging

Docker users need the new image before anything changes for them, so this is worth a release rather than sitting on main.