### PR TITLE
Show the PM2.5 reading instead of a dash

### DIFF
--- a/resources/js/pages/dashboard.js
+++ b/resources/js/pages/dashboard.js
@@ -2876,6 +2876,23 @@ function weatherDashboard() {
                     return `${t('Soil')} ${id}`;
                 },
 
+                // The payload carries ch1..ch4 alongside avg_24h_ch1 and level.
+                // Only the channels are sensors, and a channel with no reading
+                // is a sensor this station does not have.
+                pm25Channels() {
+                    const source = this.extraSensors?.pm25 || {};
+                    const channels = {};
+
+                    for (const key of ['ch1', 'ch2', 'ch3', 'ch4']) {
+                        const value = source[key];
+                        if (value !== null && value !== undefined) {
+                            channels[key] = value;
+                        }
+                    }
+
+                    return channels;
+                },
+
                 getPm25Label(key) {
                     const rawKey = String(key);
                     const match = rawKey.match(/\d+/);

--- a/resources/views/weather/dashboard.blade.php
+++ b/resources/views/weather/dashboard.blade.php
@@ -350,9 +350,13 @@
         }
         if ($ssrWidgetFlags['pm25']) {
             $lines = [];
-            foreach (array_slice((array) ($ssrExtraSensors['pm25'] ?? []), 0, 4, true) as $key => $pm) {
+            foreach (['ch1', 'ch2', 'ch3', 'ch4'] as $key) {
+                $pm = ($ssrExtraSensors['pm25'] ?? [])[$key] ?? null;
                 $value = is_array($pm) ? ($pm['current'] ?? null) : $pm;
-                $lines[] = (string) $key . ': ' . ($value !== null ? $value . ' µg/m³' : '--');
+                if ($value === null) {
+                    continue;
+                }
+                $lines[] = (string) $key . ': ' . $value . ' µg/m³';
             }
             $ssrHybridCards[] = ['id' => 'pm25', 'title' => __('PM2.5 Air Quality'), 'lines' => $lines ?: [__('No PM2.5 data')]];
         }
@@ -4014,7 +4018,7 @@
 	                </template>
 
 	                <!-- PM2.5 Widget -->
-	                <template x-if="isWidgetEnabled('pm25') && extraSensors?.pm25 && Object.keys(extraSensors.pm25).length > 0">
+	                <template x-if="isWidgetEnabled('pm25') && Object.keys(pm25Channels()).length > 0">
 		                <div class="sortable-widget bg-weather-card card-3d rounded-2xl p-5 border border-white/10"
 		                     data-widget="pm25"
 		                     @mouseenter="!editMode && tiltCard($event)" @mouseleave="!editMode && resetCard($event)" @mousemove="!editMode && tiltCard($event)">
@@ -4028,10 +4032,10 @@
                         <span class="text-xs text-gray-400">{{ __('Fine dust') }}</span>
                     </div>
                     <div class="space-y-3 text-sm">
-                        <template x-for="(data, key) in extraSensors?.pm25 || {}" :key="key">
+                        <template x-for="(value, key) in pm25Channels()" :key="key">
                             <div class="flex justify-between items-center py-2 border-b border-white/5 last:border-0">
                                 <span class="text-gray-400" x-text="getPm25Label(key)"></span>
-                                <span class="font-bold" x-text="data?.current !== undefined ? data.current + ' µg/m³' : '--'"></span>
+                                <span class="font-bold" x-text="value + ' µg/m³'"></span>
                             </div>
                         </template>
                     </div>

--- a/tests/Feature/Pm25WidgetTest.php
+++ b/tests/Feature/Pm25WidgetTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Setting;
+use App\Models\WeatherReading;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The payload carries ch1..ch4 next to avg_24h_ch1 and level. Rendering the
+ * whole map produced a row per key, including "Sensor 24" for avg_24h_ch1,
+ * and every row read "--".
+ */
+class Pm25WidgetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The card only renders when the owner has switched the widget on,
+        // and the server-rendered copy only exists with hybrid SSR turned on.
+        Setting::setValue('widgets.enabled', json_encode(['current', 'pm25']), 'string', 'widgets');
+        Setting::setValue('dashboard.hybrid_ssr_enabled', true, 'boolean', 'dashboard');
+    }
+
+    private function reading(array $attributes): void
+    {
+        WeatherReading::create(array_merge([
+            'recorded_at' => now(),
+            'temperature' => 18.0,
+        ], $attributes));
+    }
+
+    public function test_a_channel_with_a_reading_is_shown(): void
+    {
+        $this->reading(['pm25_ch1' => 8.5, 'pm25_avg_24h_ch1' => 9.1]);
+
+        $this->get('/')
+            ->assertOk()
+            ->assertSee('ch1: 8.5 µg/m³', false);
+    }
+
+    public function test_channels_without_a_sensor_are_left_out(): void
+    {
+        $this->reading(['pm25_ch1' => 8.5]);
+
+        $response = $this->get('/');
+
+        foreach (['ch2:', 'ch3:', 'ch4:'] as $absent) {
+            $response->assertDontSee($absent, false);
+        }
+    }
+
+    /** The 24 hour average and the level are not sensors and were labelled as such. */
+    public function test_the_average_and_level_are_not_listed_as_sensors(): void
+    {
+        $this->reading(['pm25_ch1' => 8.5, 'pm25_avg_24h_ch1' => 9.1]);
+
+        $this->get('/')
+            ->assertDontSee('avg_24h_ch1:', false)
+            ->assertDontSee('level:', false);
+    }
+
+    /** Zero is a real reading, not a missing sensor. */
+    public function test_a_zero_reading_is_shown(): void
+    {
+        $this->reading(['pm25_ch1' => 0]);
+
+        $this->get('/')->assertSee('ch1: 0 µg/m³', false);
+    }
+}


### PR DESCRIPTION
Fixes #86.

## What happens today

The widget loops over the whole `pm25` payload and reads `data.current` from each entry:

```html
<template x-for="(data, key) in extraSensors?.pm25 || {}" :key="key">
    <span x-text="data?.current !== undefined ? data.current + ' µg/m³' : '--'"></span>
```

But the payload holds plain numbers, not objects:

```php
'pm25' => [
    'ch1' => $this->pm25_ch1,
    ...
    'avg_24h_ch1' => $this->pm25_avg_24h_ch1,
    'level' => $this->pm25_level,
],
```

So `data.current` is always `undefined` and every row prints `--`. It also walks `avg_24h_ch1` and `level`, which are not channels, and `getPm25Label()` takes the first digits it finds in the key.

I drove the real component in a browser with the payload a one sensor station sends. Before:

```
Sensor 1   --
Sensor 2   --
Sensor 3   --
Sensor 4   --
Sensor 24  --     <- avg_24h_ch1
Sensor     --     <- level
```

Six rows, all empty, for a station with one working sensor. That matches the report, which said the value shows fine in the history but not on the dashboard.

## The fix

A `pm25Channels()` helper returns only ch1..ch4 that actually have a reading, and the template shows the value. The card hides itself when no channel has one, instead of rendering an empty box.

After, same method, same data:

```
one sensor       Sensor 1 8.5 µg/m³
two sensors      Sensor 1 8.5 µg/m³ / Sensor 2 12 µg/m³
a zero reading   Sensor 1 0 µg/m³
no sensors       card hidden
```

Zero is checked on purpose: it is a real reading and a `!value` test would have dropped it.

## Also

The server-rendered fallback had the same list problem, printing a `--` line for every channel the station does not own. It now skips them. That path already handled both value shapes, which is why the reporter saw the right number in history.

## Tests

Four new, covering the rendered card: a channel with a reading appears, channels without a sensor do not, the average and level are not listed as sensors, and zero is shown. I reverted the fix and confirmed they fail, rather than trusting a green run.

The client-side behaviour is not in the PHP suite. It was checked by driving the live component through Alpine in a browser, and the `pm25Channels()` helper was run against the real `dashboard.js` in Node for the five input shapes above.

476 tests, 1456 assertions.