### PR TITLE
Let the dashboard radar zoom in past its default

### DIFF
--- a/resources/js/pages/dashboard.js
+++ b/resources/js/pages/dashboard.js
@@ -2,6 +2,15 @@ const cfg = window.__METEO_DASHBOARD_CONFIG__ || {};
 const t = (key) => cfg.i18n?.[key] ?? key;
 const locale = window.Meteo?.jsLocale || 'en-US';
 const hybridSsrEnabled = window.__METEO_DASHBOARD_HYBRID__ === true;
+
+// RainViewer has radar data up to zoom 7. Ask for a tile above that and it
+// answers with a solid near-black opaque square, which would black out the
+// map, so the radar layers stop requesting new tiles there and Leaflet scales
+// the last real one instead. The map itself can go further because the street
+// map underneath has plenty more detail, and stopping at 7 left the "+" button
+// greyed out on every default install.
+const RADAR_MAX_ZOOM = 10;
+const RADAR_MAX_DATA_ZOOM = 7;
 const initialPayload = (window.__METEO_DASHBOARD_INITIAL__ && typeof window.__METEO_DASHBOARD_INITIAL__ === 'object')
     ? window.__METEO_DASHBOARD_INITIAL__
     : null;
@@ -1688,7 +1697,7 @@ function weatherDashboard() {
                     }
 
                     const configuredZoom = Number(cfg.rainviewerZoom || 7);
-                    const clampedZoom = Math.min(Math.max(configuredZoom || 7, 0), 7);
+                    const clampedZoom = Math.min(Math.max(configuredZoom || 7, 0), RADAR_MAX_ZOOM);
                     const useProxy = Boolean(cfg.radarUseProxy);
 
                     this._radarMap = L.map(radarMapWidget, {
@@ -1696,7 +1705,7 @@ function weatherDashboard() {
                         zoom: clampedZoom,
                         zoomControl: false,
                         attributionControl: false,
-                        maxZoom: 7,
+                        maxZoom: RADAR_MAX_ZOOM,
                         minZoom: 0,
                         zoomAnimation: false,
                     });
@@ -1704,7 +1713,7 @@ function weatherDashboard() {
                     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                         attribution: '&copy; OpenStreetMap contributors',
                         minZoom: 0,
-                        maxZoom: 7,
+                        maxZoom: RADAR_MAX_ZOOM,
                     }).addTo(this._radarMap);
 
                     const stationIcon = L.divIcon({
@@ -2038,12 +2047,13 @@ function weatherDashboard() {
                         const previousLayer = this._radarLayer;
                         const layerOpacity = Number.isFinite(Number(frame.opacity)) ? Number(frame.opacity) : 0.7;
                         const minZoom = Number.isFinite(Number(frame.minZoom)) ? Number(frame.minZoom) : 0;
-                        const maxZoom = Number.isFinite(Number(frame.maxZoom)) ? Number(frame.maxZoom) : 7;
+                        const maxNativeZoom = Number.isFinite(Number(frame.maxZoom)) ? Number(frame.maxZoom) : RADAR_MAX_DATA_ZOOM;
                         const nextLayer = window.L.tileLayer(frame.tileUrlTemplate, {
                             opacity: layerOpacity,
                             attribution: String(frame.attribution || 'Future radar'),
                             minZoom,
-                            maxZoom,
+                            maxZoom: RADAR_MAX_ZOOM,
+                            maxNativeZoom,
                             tms: false,
                             crossOrigin: true,
                         });
@@ -2068,7 +2078,8 @@ function weatherDashboard() {
                         opacity: 0.7,
                         attribution: 'RainViewer',
                         minZoom: 0,
-                        maxZoom: 7,
+                        maxZoom: RADAR_MAX_ZOOM,
+                        maxNativeZoom: RADAR_MAX_DATA_ZOOM,
                         tms: false,
                         crossOrigin: true,
                     });


### PR DESCRIPTION
Fixes #59.

## The bug

The widget opens at zoom 7, the map was built with `maxZoom: 7`, and the seeded default for `radar.rainviewer_zoom` is 7. So `radarCanZoomIn()` returned false from first paint and `:disabled="!radarCanZoomIn()"` greyed the "+" button out on every install that had not changed the setting.

Reproduced by running the real `initializeRadarMap()` in Node with a stubbed Leaflet:

```
map      zoom=7 maxZoom=7 minZoom=0
at the default zoom, "+" enabled: false
```

## Why raising the cap alone would be worse

#59 suggested letting `maxZoom` exceed the default. On its own that breaks the map. RainViewer only has radar to zoom 7, and it does not 404 above that, it answers **200 with a solid opaque near-black tile**:

```
z=7   14628 bytes   40 colours, mostly transparent, real radar
z=8    1370 bytes    8 colours, every pixel opaque, RGB ~000000
z=10   1370 bytes    same
```

Zooming in would have covered the map in black squares.

## The fix

The map and the street layer go to 10. The radar layers keep `maxNativeZoom: 7`, so Leaflet stops requesting radar tiles above 7 and scales the deepest real one over a sharper street map. The satellite page already uses `maxNativeZoom` for GIBS layers, so the pattern is not new here.

The forecast frame layer gets the same treatment, using the provider's own max as its native cap.

## Verified

Same harness, after:

```
map            zoom=7 maxZoom=10 minZoom=0
radar overlay  maxZoom=10 maxNativeZoom=7
at the default zoom, "+" enabled: true
```

Then in a browser on the real dashboard, clicking the actual "+" twice and reading the network log. Requests before and after:

```
before   .../512/6/...      map at zoom 7
after    .../512/7/20/49/   repeatedly, map at zoom 9
```

Nothing above 7 was ever requested, which is the whole point. The street map went from zoom 7 to 9 and the widget still renders normally, no black tiles.

476 tests pass, though none of them can see a Leaflet option.

## Not changed

The standalone `/radar` page has the same ceiling of 7 in three places. I left it alone because #59 is about the dashboard widget and that page has its own provider switching to think about. Worth a separate look if the deeper zoom turns out to be useful here.