### PR TITLE
Make DWD reachable: picker option, settings page and menu link

### DIFF
--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -97,6 +97,13 @@ class SettingsController extends Controller
             'color' => 'amber',
             'category' => 'datasources',
         ],
+        'dwd' => [
+            'label' => 'DWD',
+            'description' => 'Deutscher Wetterdienst MOSMIX forecast station',
+            'icon' => 'sun',
+            'color' => 'amber',
+            'category' => 'datasources',
+        ],
         'ecowitt' => [
             'label' => 'Ecowitt',
             'description' => 'Ecowitt local push or cloud API settings',

--- a/database/migrations/2026_09_04_120000_add_dwd_forecast_settings.php
+++ b/database/migrations/2026_09_04_120000_add_dwd_forecast_settings.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * DWD arrived as a forecast service with no way to reach it.
+ *
+ * The forecast picker is built from the options string on
+ * forecast.default_source, so a source missing from that string cannot be
+ * chosen however well it works. Existing installs never reseed, so the option
+ * has to be appended here rather than only in the seeder.
+ */
+return new class extends Migration
+{
+    private const OPTION = 'fct_dwd_block.php:DWD';
+
+    public function up(): void
+    {
+        DB::table('settings')->insertOrIgnore([
+            'key' => 'dwd.station_id',
+            'value' => '',
+            'type' => 'string',
+            'group' => 'dwd',
+            'description' => 'DWD MOSMIX station id, e.g. 10382 for Berlin-Tegel. Leave empty to use the nearest station',
+            'options' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $row = DB::table('settings')->where('key', 'forecast.default_source')->first();
+
+        if ($row === null) {
+            return;
+        }
+
+        $options = (string) ($row->options ?? '');
+
+        // Appending twice would put DWD in the dropdown twice.
+        if ($options === '' || str_contains($options, 'fct_dwd_block.php')) {
+            return;
+        }
+
+        DB::table('settings')
+            ->where('key', 'forecast.default_source')
+            ->update([
+                'options' => $options.','.self::OPTION,
+                'updated_at' => now(),
+            ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('settings')->where('key', 'dwd.station_id')->delete();
+
+        $row = DB::table('settings')->where('key', 'forecast.default_source')->first();
+
+        if ($row === null) {
+            return;
+        }
+
+        $options = (string) ($row->options ?? '');
+
+        DB::table('settings')
+            ->where('key', 'forecast.default_source')
+            ->update([
+                'options' => trim(str_replace([','.self::OPTION, self::OPTION], '', $options), ','),
+                'updated_at' => now(),
+            ]);
+    }
+};

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -264,8 +264,11 @@ class SettingsSeeder extends Seeder
             ['key' => 'navigation.alerts_enabled', 'value' => '1', 'type' => 'boolean', 'group' => 'navigation', 'description' => 'Show Alerts in navigation and allow route access'],
 
             // ===== Forecast Settings =====
-            ['key' => 'forecast.default_source', 'value' => 'fct_yrno_block.php', 'type' => 'select', 'group' => 'forecast', 'description' => 'Default forecast source', 'options' => 'fct_yrno_block.php:Yr.no,fct_wu_block.php:Weather Underground,fct_darksky_block.php:OpenWeatherMap,fct_wxsim_block.php:WXSIM,fct_ec_block.php:Environment Canada,fct_tempest_block.php:WeatherFlow Tempest,fct_aemet_block.php:AEMET'],
+            ['key' => 'forecast.default_source', 'value' => 'fct_yrno_block.php', 'type' => 'select', 'group' => 'forecast', 'description' => 'Default forecast source', 'options' => 'fct_yrno_block.php:Yr.no,fct_wu_block.php:Weather Underground,fct_darksky_block.php:OpenWeatherMap,fct_wxsim_block.php:WXSIM,fct_ec_block.php:Environment Canada,fct_tempest_block.php:WeatherFlow Tempest,fct_aemet_block.php:AEMET,fct_dwd_block.php:DWD'],
             ['key' => 'forecast.sky_source', 'value' => 'ccn_metar_block.php', 'type' => 'select', 'group' => 'forecast', 'description' => 'Sky conditions source', 'options' => 'ccn_metar_block.php:METAR,ccn_ec_block.php:Environment Canada,ccn_noaa_block.php:NOAA'],
+            // DWD MOSMIX. The station is optional: left empty the nearest one
+            // to the station coordinates is used.
+            ['key' => 'dwd.station_id', 'value' => '', 'type' => 'string', 'group' => 'dwd', 'description' => 'DWD MOSMIX station id, e.g. 10382 for Berlin-Tegel. Leave empty to use the nearest station'],
             // WXSIM plaintext forecast integration
             ['key' => 'wxsim.enabled', 'value' => '0', 'type' => 'boolean', 'group' => 'wxsim', 'description' => 'Enable WXSIM plaintext forecast integration'],
             ['key' => 'wxsim.file_path', 'value' => storage_path('app/wxsim/plaintext.txt'), 'type' => 'string', 'group' => 'wxsim', 'description' => 'Path to WXSIM plaintext forecast file (plaintext.txt). Leave as default if you copy the file into storage/app/wxsim/plaintext.txt'],

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -274,7 +274,7 @@
                 </details>
 
                 <!-- DATA SOURCES -->
-                <details class="sidebar-section" {{ request()->is('admin/settings/ecowitt') || request()->is('admin/settings/wunderground') || request()->is('admin/settings/weatherflow') || request()->is('admin/settings/weatherlink') || request()->is('admin/settings/ambient') || request()->is('admin/settings/openweathermap') || request()->is('admin/settings/yrno') || request()->is('admin/settings/wxsim') || request()->is('admin/settings/environment_canada') || request()->is('admin/settings/airquality') || request()->is('admin/settings/pollen') || request()->is('admin/settings/aviation') || request()->is('admin/settings/tide') || request()->is('admin/settings/waves') || request()->is('admin/settings/rivers') || request()->is('admin/settings/opendata') ? 'open' : '' }}>
+                <details class="sidebar-section" {{ request()->is('admin/settings/ecowitt') || request()->is('admin/settings/wunderground') || request()->is('admin/settings/weatherflow') || request()->is('admin/settings/weatherlink') || request()->is('admin/settings/ambient') || request()->is('admin/settings/openweathermap') || request()->is('admin/settings/yrno') || request()->is('admin/settings/wxsim') || request()->is('admin/settings/environment_canada') || request()->is('admin/settings/airquality') || request()->is('admin/settings/pollen') || request()->is('admin/settings/aviation') || request()->is('admin/settings/tide') || request()->is('admin/settings/waves') || request()->is('admin/settings/rivers') || request()->is('admin/settings/opendata') || request()->is('admin/settings/aemet') || request()->is('admin/settings/dwd') ? 'open' : '' }}>
                     <summary class="px-3 py-2 text-xs font-semibold text-slate-500 uppercase tracking-wider cursor-pointer flex items-center justify-between hover:text-slate-300">
                         {{ __('Data Sources') }}
                         <svg class="w-4 h-4 sidebar-chevron transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -318,6 +318,20 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                             </svg>
                             <span>{{ __('Yr.no') }}</span>
+                        </a>
+                        <a href="{{ route('admin.settings.group', 'dwd') }}"
+                           class="flex items-center space-x-2 px-3 py-1.5 rounded-lg {{ request()->is('admin/settings/dwd') ? 'bg-slate-700 text-white' : 'text-slate-300 hover:bg-slate-700' }}">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+                            </svg>
+                            <span>{{ __('DWD') }}</span>
+                        </a>
+                        <a href="{{ route('admin.settings.group', 'aemet') }}"
+                           class="flex items-center space-x-2 px-3 py-1.5 rounded-lg {{ request()->is('admin/settings/aemet') ? 'bg-slate-700 text-white' : 'text-slate-300 hover:bg-slate-700' }}">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+                            </svg>
+                            <span>{{ __('AEMET') }}</span>
                         </a>
                         <a href="{{ route('admin.settings.group', 'wxsim') }}" 
                            class="flex items-center space-x-2 px-3 py-1.5 rounded-lg {{ request()->is('admin/settings/wxsim') ? 'bg-slate-700 text-white' : 'text-slate-300 hover:bg-slate-700' }}">

--- a/tests/Feature/DwdConfigurationTest.php
+++ b/tests/Feature/DwdConfigurationTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * DwdService shipped without any way to reach it: the forecast picker is built
+ * from a seeded options string that did not list DWD, there was no settings
+ * group for the station id, and the scheduler pointed at a group that 404s.
+ */
+class DwdConfigurationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        return User::factory()->create(['is_admin' => true]);
+    }
+
+    public function test_dwd_is_offered_in_the_forecast_source_picker(): void
+    {
+        $this->seed(\Database\Seeders\SettingsSeeder::class);
+
+        $options = Setting::where('key', 'forecast.default_source')->value('options');
+
+        $this->assertStringContainsString('fct_dwd_block.php:DWD', (string) $options);
+    }
+
+    public function test_an_admin_can_select_dwd_and_it_is_the_service_that_answers(): void
+    {
+        $this->seed(\Database\Seeders\SettingsSeeder::class);
+
+        $this->actingAs($this->admin())
+            ->post('/admin/settings/forecast', ['forecast_default_source' => 'fct_dwd_block.php'])
+            ->assertRedirect();
+
+        $this->assertSame('fct_dwd_block.php', Setting::getValue('forecast.default_source'));
+        $this->assertInstanceOf(
+            \App\Services\Forecast\DwdService::class,
+            \App\Services\Forecast\ForecastServiceFactory::make()
+        );
+    }
+
+    public function test_the_dwd_settings_page_exists(): void
+    {
+        $this->seed(\Database\Seeders\SettingsSeeder::class);
+
+        $this->actingAs($this->admin())
+            ->get('/admin/settings/dwd')
+            ->assertOk()
+            ->assertSee('DWD');
+    }
+
+    /** The station is optional, but it has to be reachable to be optional. */
+    public function test_the_station_id_is_a_setting_an_admin_can_write(): void
+    {
+        $this->seed(\Database\Seeders\SettingsSeeder::class);
+
+        $this->assertNotNull(Setting::where('key', 'dwd.station_id')->first());
+
+        $this->actingAs($this->admin())
+            ->post('/admin/settings/dwd', ['dwd_station_id' => '10382'])
+            ->assertRedirect();
+
+        $this->assertSame('10382', Setting::getValue('dwd.station_id'));
+    }
+
+    /**
+     * The sidebar is hardcoded and the group registry is separate, so they
+     * drift apart quietly. aemet, and now dwd, were registered pages with no
+     * link, reachable only by typing the URL.
+     */
+    public function test_every_data_source_page_is_reachable_from_the_sidebar(): void
+    {
+        $sidebar = file_get_contents(resource_path('views/layouts/admin.blade.php'));
+
+        foreach (['dwd', 'aemet'] as $group) {
+            $this->assertStringContainsString(
+                "route('admin.settings.group', '{$group}')",
+                $sidebar,
+                "{$group} has a settings page but no way to reach it"
+            );
+        }
+    }
+
+    /** An install that upgrades gets the option too, without reseeding. */
+    public function test_the_migration_adds_dwd_to_an_existing_options_string(): void
+    {
+        Setting::where('key', 'forecast.default_source')->delete();
+        Setting::create([
+            'key' => 'forecast.default_source',
+            'value' => 'fct_yrno_block.php',
+            'type' => 'select',
+            'group' => 'forecast',
+            'description' => 'Default forecast source',
+            'options' => 'fct_yrno_block.php:Yr.no,fct_aemet_block.php:AEMET',
+        ]);
+
+        (require base_path('database/migrations/2026_09_04_120000_add_dwd_forecast_settings.php'))->up();
+
+        $options = (string) Setting::where('key', 'forecast.default_source')->value('options');
+        $this->assertStringContainsString('fct_dwd_block.php:DWD', $options);
+        $this->assertStringContainsString('fct_aemet_block.php:AEMET', $options, 'existing options were lost');
+        $this->assertSame(1, substr_count($options, 'fct_dwd_block.php'), 'running twice must not duplicate');
+    }
+}


### PR DESCRIPTION
Follow-up to #95. That PR added a working DWD forecast service with no way to get to it. This is my fault and the PR description made it worse by claiming enabling DWD "makes it appear in the forecast source list".

## What was actually wrong

The forecast picker does exist, at **Admin > Settings > Forecast**. It is a plain `<select>` the generic settings view builds from the `options` string on the `forecast.default_source` row:

```
fct_yrno_block.php:Yr.no,fct_wu_block.php:Weather Underground,...,fct_aemet_block.php:AEMET
```

DWD was never added to that string, so it could not be chosen at all. The only route to it was editing the database by hand.

Two more holes behind it:

- I referenced settings group `'dwd'` for the scheduler row, and no such group exists. That link 404s at `SettingsController::group()`.
- `DwdService` reads `dwd.station_id`, which was never seeded, so there was no page and no field for it.

Between them, that is exactly what @centauri saw: switch DWD on, nothing appears.

## What the Open Data toggle actually does

Worth writing down, because the expectation was reasonable and the app does not meet it. Across the whole codebase there are two reads of an `opendata.*.enabled` key. Only one changes behaviour: `opendata.noaa.enabled` can select NOAA radar future frames, and only when the radar provider is on "auto". Every other toggle, KNMI and AEMET included, is written and never read.

So the Open Data page is a catalogue with a switch that mostly does nothing. Not changed here, but it should not be left implied that it configures anything.

## This PR

- adds `fct_dwd_block.php:DWD` to the picker options, in the seeder and in a migration so upgrades get it without reseeding
- registers the `dwd` settings group and seeds `dwd.station_id`, empty, meaning "use the nearest station"
- adds the sidebar link

It also **adds a sidebar link for AEMET**, which has been a registered settings page with no link since #22, reachable only by typing the URL. Four groups are in that state; AEMET is the one a user is most likely to want.

## Tests

Six new, 491 total:

- DWD appears in the picker options
- an admin can POST the picker and `ForecastServiceFactory::make()` then returns `DwdService`
- `/admin/settings/dwd` returns 200 and the station id can be saved through it
- the migration appends the option, keeps the existing ones, and does not duplicate on a second run
- every data source page has a sidebar link, so the drift that stranded AEMET fails a test next time

Checked in a browser as well, since "nothing appeared" was the complaint: the picker lists DWD, and the DWD page renders with its station field and a working sidebar entry.

## Still open

`forecast.default_source` accepts any string with no validation and falls back to Yr.no at runtime, so a bad value looks saved but is not used. Separate from this, and worth its own fix.