### PR TITLE
Stop every forecast source except Yr.no from going dark

### DIFF
--- a/app/Console/Commands/CheckSensorHealth.php
+++ b/app/Console/Commands/CheckSensorHealth.php
@@ -202,7 +202,14 @@ class CheckSensorHealth extends Command
     {
         $latitude = Setting::latitude();
         $longitude = Setting::longitude();
-        $cacheKey = "yrno_forecast_{$latitude}_{$longitude}";
+        // Whatever source is configured, not always Yr.no. This is why every
+        // other source showed "Offline" about an hour after being selected,
+        // and sent an alert titled "Forecast Data (Yr.no)". Issue #99.
+        $cacheKey = \App\Support\ForecastCacheKeys::forSource(
+            (string) Setting::getValue('forecast.default_source', 'fct_yrno_block.php'),
+            $latitude,
+            $longitude
+        );
 
         $forecastData = Cache::get($cacheKey);
 
@@ -210,7 +217,7 @@ class CheckSensorHealth extends Command
         $isStale = $this->healthStatus['forecast']['is_stale'];
 
         if ($isStale && $forecastData === null) {
-            $this->sendAlertIfNeeded('forecast', 'Forecast Data (Yr.no)', 'Forecast data not available.');
+            $this->sendAlertIfNeeded('forecast', 'Forecast Data', 'Forecast data not available.');
         } else {
             $this->clearAlertIfNeeded('forecast', 'Forecast Data');
         }

--- a/app/Console/Commands/PollExternalData.php
+++ b/app/Console/Commands/PollExternalData.php
@@ -778,13 +778,32 @@ class PollExternalData extends Command
             $cacheKey = "forecast_{$latitude}_{$longitude}";
             $sourceCacheKey = $this->getSourceCacheKey($source, $latitude, $longitude);
 
+            // Keep what we have. The forget below is what stops the service
+            // handing back its own cached copy, but a failed fetch used to
+            // leave both keys empty and the message below was a lie: one bad
+            // poll turned into an empty forecast until the next good one.
+            $previous = [
+                $sourceCacheKey => Cache::get($sourceCacheKey),
+                $cacheKey => Cache::get($cacheKey),
+            ];
+
             // Force fresh API fetch: clear cache so the service doesn't return stale data
             // (otherwise we keep re-caching the same old forecast and "today" drifts, leaving fewer days)
             Cache::forget($sourceCacheKey);
             Cache::forget($cacheKey);
 
-            $service = ForecastServiceFactory::make();
-            $data = $service->fetchForecast();
+            try {
+                $service = ForecastServiceFactory::make();
+                $data = $service->fetchForecast();
+            } catch (\Throwable $e) {
+                // Throwable, not Exception: an unreadable API key used to reach
+                // a typed property and throw a TypeError right here.
+                $this->restoreForecast($previous);
+                $this->error("   Error building {$sourceName}: {$e->getMessage()} (kept existing cache)");
+                Log::error('Poll forecast failed', ['error' => $e->getMessage(), 'source' => $source]);
+
+                return false;
+            }
 
             if ($data && isset($data['forecast']) && count($data['forecast']) > 0) {
                 CacheFreshness::put($sourceCacheKey, $data, now()->addMinutes($this->cacheTTLs['forecast']));
@@ -793,10 +812,12 @@ class PollExternalData extends Command
                 return true;
             }
 
-            $this->warn('   No forecast data received (keeping existing cache)');
+            $this->restoreForecast($previous);
+            $this->warn('   No forecast data received (kept existing cache)');
             return false;
-        } catch (\Exception $e) {
-            $this->error("   Error: {$e->getMessage()} (keeping existing cache)");
+        } catch (\Throwable $e) {
+            $this->restoreForecast($previous ?? []);
+            $this->error("   Error: {$e->getMessage()} (kept existing cache)");
             Log::error('Poll forecast failed', ['error' => $e->getMessage(), 'source' => $source]);
             return false;
         }
@@ -852,19 +873,25 @@ class PollExternalData extends Command
         return $names[$source] ?? 'forecast service';
     }
 
+    /**
+     * Put back what was there before the forced refresh, so a failed poll
+     * costs nothing. Only non-empty payloads are restored: an empty one is
+     * what we were trying to replace.
+     *
+     * @param array<string, mixed> $previous
+     */
+    private function restoreForecast(array $previous): void
+    {
+        foreach ($previous as $key => $payload) {
+            if (is_array($payload) && !empty($payload['forecast'])) {
+                CacheFreshness::put($key, $payload, now()->addMinutes($this->cacheTTLs['forecast']));
+            }
+        }
+    }
+
     private function getSourceCacheKey(string $source, float $latitude, float $longitude): string
     {
-        $stationId = Setting::getValue('weatherflow.station_id', '');
-        $keys = [
-            'fct_yrno_block.php' => "yrno_forecast_{$latitude}_{$longitude}",
-            'fct_darksky_block.php' => "openweathermap_forecast_{$latitude}_{$longitude}",
-            'fct_wu_block.php' => "wunderground_forecast_{$latitude}_{$longitude}",
-            'fct_wxsim_block.php' => "wxsim_forecast_" . md5(Setting::getValue('wxsim.file_path', '')),
-            'fct_ec_block.php' => "ec_forecast_{$latitude}_{$longitude}",
-            'fct_tempest_block.php' => 'tempest_forecast_' . ($stationId !== '' ? $stationId : '0'),
-            'fct_aemet_block.php' => "aemet_forecast_" . Setting::getValue('aemet.municipio', ''),
-        ];
-        return $keys[$source] ?? "forecast_{$latitude}_{$longitude}";
+        return \App\Support\ForecastCacheKeys::forSource($source, $latitude, $longitude);
     }
 
     private function pollAirQuality(): bool

--- a/app/Http/Controllers/Api/WeatherController.php
+++ b/app/Http/Controllers/Api/WeatherController.php
@@ -107,21 +107,12 @@ class WeatherController extends Controller
         $latitude = Setting::latitude();
         $longitude = Setting::longitude();
         $source = Setting::getValue('forecast.default_source', 'fct_yrno_block.php');
-        $stationId = Setting::getValue('weatherflow.station_id', '');
-        $sourceKeys = [
-            'fct_yrno_block.php' => "yrno_forecast_{$latitude}_{$longitude}",
-            'fct_darksky_block.php' => "openweathermap_forecast_{$latitude}_{$longitude}",
-            'fct_wu_block.php' => "wunderground_forecast_{$latitude}_{$longitude}",
-            'fct_wxsim_block.php' => "wxsim_forecast_" . md5(Setting::getValue('wxsim.file_path', '')),
-            'fct_ec_block.php' => "ec_forecast_{$latitude}_{$longitude}",
-            'fct_tempest_block.php' => 'tempest_forecast_' . ($stationId !== '' ? $stationId : '0'),
-            'fct_aemet_block.php' => "aemet_forecast_" . Setting::getValue('aemet.municipio', ''),
-            'fct_dwd_block.php' => 'dwd_forecast_' . Setting::getValue('dwd.station_id', ''),
-        ];
+        $forecastData = Cache::get(\App\Support\ForecastCacheKeys::forSource($source, $latitude, $longitude));
 
-        $forecastData = Cache::get($sourceKeys[$source] ?? null);
-        if (!$forecastData) {
-            $forecastData = Cache::get("forecast_{$latitude}_{$longitude}");
+        // An empty payload is a miss, not a hit. A source that cached a
+        // well formed but empty envelope used to block this fallback.
+        if (!$forecastData || empty($forecastData['forecast'])) {
+            $forecastData = Cache::get(\App\Support\ForecastCacheKeys::generic($latitude, $longitude)) ?: $forecastData;
         }
 
         $forecast = is_array($forecastData) ? ($forecastData['forecast'] ?? null) : null;

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -34,7 +34,17 @@ class Setting extends Model
             return $default;
         }
 
-        return $setting->getCastedValue();
+        $value = $setting->getCastedValue();
+
+        // An encrypted row reads back as null when it is empty or cannot be
+        // decrypted, which happens when APP_KEY changes. Callers that asked for
+        // a default want that default, not a null they were not expecting: it
+        // used to reach typed string properties and throw.
+        if ($value === null && $default !== null) {
+            return $default;
+        }
+
+        return $value;
     }
 
     /**

--- a/app/Services/Alerts/LocalWarningService.php
+++ b/app/Services/Alerts/LocalWarningService.php
@@ -132,15 +132,8 @@ class LocalWarningService
         $lon    = Setting::longitude();
         $source = Setting::getValue('forecast.default_source', 'fct_yrno_block.php');
 
-        $sourceKeys = [
-            'fct_yrno_block.php'    => "yrno_forecast_{$lat}_{$lon}",
-            'fct_darksky_block.php' => "openweathermap_forecast_{$lat}_{$lon}",
-            'fct_wu_block.php'      => "wunderground_forecast_{$lat}_{$lon}",
-            'fct_ec_block.php'      => "ec_forecast_{$lat}_{$lon}",
-            'fct_aemet_block.php'   => "aemet_forecast_" . Setting::getValue('aemet.municipio', ''),
-        ];
 
-        $forecastData = Cache::get($sourceKeys[$source] ?? null)
+        $forecastData = Cache::get(\App\Support\ForecastCacheKeys::forSource($source, $lat, $lon))
                      ?? Cache::get("forecast_{$lat}_{$lon}");
 
         if (!is_array($forecastData)) return null;
@@ -521,15 +514,8 @@ class LocalWarningService
         $lon    = Setting::longitude();
         $source = Setting::getValue('forecast.default_source', 'fct_yrno_block.php');
 
-        $sourceKeys = [
-            'fct_yrno_block.php'    => "yrno_forecast_{$lat}_{$lon}",
-            'fct_darksky_block.php' => "openweathermap_forecast_{$lat}_{$lon}",
-            'fct_wu_block.php'      => "wunderground_forecast_{$lat}_{$lon}",
-            'fct_ec_block.php'      => "ec_forecast_{$lat}_{$lon}",
-            'fct_aemet_block.php'   => "aemet_forecast_" . Setting::getValue('aemet.municipio', ''),
-        ];
 
-        $forecastData = Cache::get($sourceKeys[$source] ?? null)
+        $forecastData = Cache::get(\App\Support\ForecastCacheKeys::forSource($source, $lat, $lon))
                      ?? Cache::get("forecast_{$lat}_{$lon}");
 
         if (!is_array($forecastData)) return null;
@@ -634,15 +620,8 @@ class LocalWarningService
         $lon    = Setting::longitude();
         $source = Setting::getValue('forecast.default_source', 'fct_yrno_block.php');
 
-        $sourceKeys = [
-            'fct_yrno_block.php'    => "yrno_forecast_{$lat}_{$lon}",
-            'fct_darksky_block.php' => "openweathermap_forecast_{$lat}_{$lon}",
-            'fct_wu_block.php'      => "wunderground_forecast_{$lat}_{$lon}",
-            'fct_ec_block.php'      => "ec_forecast_{$lat}_{$lon}",
-            'fct_aemet_block.php'   => "aemet_forecast_" . Setting::getValue('aemet.municipio', ''),
-        ];
 
-        $forecastData = Cache::get($sourceKeys[$source] ?? null)
+        $forecastData = Cache::get(\App\Support\ForecastCacheKeys::forSource($source, $lat, $lon))
                      ?? Cache::get("forecast_{$lat}_{$lon}");
 
         if (!is_array($forecastData)) return null;

--- a/app/Services/Dashboard/DashboardPayloadService.php
+++ b/app/Services/Dashboard/DashboardPayloadService.php
@@ -385,16 +385,7 @@ class DashboardPayloadService
         // Forecast data (cached by poller)
         $source = Setting::getValue('forecast.default_source', 'fct_yrno_block.php');
         $stationId = Setting::getValue('weatherflow.station_id', '');
-        $sourceKeys = [
-            'fct_yrno_block.php' => "yrno_forecast_{$latitude}_{$longitude}",
-            'fct_darksky_block.php' => "openweathermap_forecast_{$latitude}_{$longitude}",
-            'fct_wu_block.php' => "wunderground_forecast_{$latitude}_{$longitude}",
-            'fct_wxsim_block.php' => 'wxsim_forecast_' . md5(Setting::getValue('wxsim.file_path', '')),
-            'fct_ec_block.php' => "ec_forecast_{$latitude}_{$longitude}",
-            'fct_tempest_block.php' => 'tempest_forecast_' . ($stationId !== '' ? $stationId : '0'),
-            'fct_aemet_block.php' => "aemet_forecast_" . Setting::getValue('aemet.municipio', ''),
-        ];
-        $forecastData = Cache::get($sourceKeys[$source] ?? null);
+        $forecastData = Cache::get(\App\Support\ForecastCacheKeys::forSource($source));
         if (!$forecastData) {
             $forecastData = Cache::get("forecast_{$latitude}_{$longitude}");
         }

--- a/app/Services/Forecast/DwdService.php
+++ b/app/Services/Forecast/DwdService.php
@@ -7,6 +7,7 @@ namespace App\Services\Forecast;
 use App\Contracts\Forecast\ForecastServiceInterface;
 use App\Models\Setting;
 use App\Support\CacheFreshness;
+use App\Support\ForecastCacheKeys;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -39,7 +40,7 @@ class DwdService implements ForecastServiceInterface
             return null;
         }
 
-        return CacheFreshness::remember("dwd_forecast_{$station}", self::CACHE_TTL, function () use ($station) {
+        return CacheFreshness::remember(ForecastCacheKeys::forSource('fct_dwd_block.php'), self::CACHE_TTL, function () use ($station) {
             $url = self::BASE_URL."/{$station}/kml/MOSMIX_L_LATEST_{$station}.kmz";
 
             try {
@@ -218,6 +219,10 @@ class DwdService implements ForecastServiceInterface
         }
 
         return [
+            'updated_at' => now()->toIso8601String(),
+            // 'forecast' is the key the poller and both readers look for. Without
+            // it the payload is dropped on every poll, however good it is.
+            'forecast' => $hourly,
             'station' => [
                 'id' => (string) (($xml->xpath('//kml:Placemark/kml:name')[0] ?? '')),
                 'name' => (string) (($xml->xpath('//kml:Placemark/kml:description')[0] ?? '')),

--- a/app/Support/ForecastCacheKeys.php
+++ b/app/Support/ForecastCacheKeys.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Models\Setting;
+
+/**
+ * Where each forecast source keeps its cached payload.
+ *
+ * This map was copied into seven places and every copy disagreed. The reader
+ * built the DWD key from the configured station while the writer used the one
+ * it resolved, so with the station left empty, which is the default, the two
+ * never met. Issue #99.
+ */
+class ForecastCacheKeys
+{
+    /** Every source falls back to this when it has no key of its own. */
+    public static function generic(?float $latitude = null, ?float $longitude = null): string
+    {
+        $latitude ??= Setting::latitude();
+        $longitude ??= Setting::longitude();
+
+        return "forecast_{$latitude}_{$longitude}";
+    }
+
+    public static function forSource(string $source, ?float $latitude = null, ?float $longitude = null): string
+    {
+        $latitude ??= Setting::latitude();
+        $longitude ??= Setting::longitude();
+
+        return match ($source) {
+            'fct_yrno_block.php' => "yrno_forecast_{$latitude}_{$longitude}",
+            'fct_darksky_block.php' => "openweathermap_forecast_{$latitude}_{$longitude}",
+            'fct_wu_block.php' => "wunderground_forecast_{$latitude}_{$longitude}",
+            'fct_wxsim_block.php' => 'wxsim_forecast_'.md5((string) Setting::getValue('wxsim.file_path', '')),
+            'fct_ec_block.php' => "ec_forecast_{$latitude}_{$longitude}",
+            'fct_tempest_block.php' => 'tempest_forecast_'.self::orZero(Setting::getValue('weatherflow.station_id', '')),
+            'fct_aemet_block.php' => 'aemet_forecast_'.Setting::getValue('aemet.municipio', ''),
+            'fct_dwd_block.php' => 'dwd_forecast_'.self::dwdStation(),
+            default => self::generic($latitude, $longitude),
+        };
+    }
+
+    /**
+     * The station the service will actually use, which is the configured one
+     * or the nearest it resolved. Resolution is cached by the service, so this
+     * does not go to the network on its own.
+     */
+    private static function dwdStation(): string
+    {
+        $configured = trim((string) Setting::getValue('dwd.station_id', ''));
+
+        if ($configured !== '') {
+            return $configured;
+        }
+
+        return (string) \Illuminate\Support\Facades\Cache::get(
+            'dwd_nearest_station_'.round(Setting::latitude(), 3).'_'.round(Setting::longitude(), 3),
+            ''
+        );
+    }
+
+    private static function orZero(mixed $value): string
+    {
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : '0';
+    }
+}

--- a/tests/Feature/DwdForecastServiceTest.php
+++ b/tests/Feature/DwdForecastServiceTest.php
@@ -161,6 +161,37 @@ class DwdForecastServiceTest extends TestCase
         Http::assertSent(fn ($request) => str_contains($request->url(), '06240'));
     }
 
+    /**
+     * Issue #99. The poller and both readers require a top-level 'forecast'
+     * key, so an envelope with only 'hourly' was thrown away on every poll.
+     */
+    public function test_the_payload_carries_a_forecast_key_like_every_other_source(): void
+    {
+        $this->fakeMosmix();
+
+        $forecast = app(DwdService::class)->fetchForecast();
+
+        $this->assertIsArray($forecast);
+        $this->assertArrayHasKey('forecast', $forecast, 'the poller drops anything without this');
+        $this->assertNotEmpty($forecast['forecast']);
+        $this->assertArrayHasKey('updated_at', $forecast);
+    }
+
+    /** The reader built the key from the setting, the writer from the resolved station. */
+    public function test_the_cache_key_matches_the_one_the_page_reads(): void
+    {
+        Setting::setValue('dwd.station_id', '', 'string', 'dwd');
+        $this->fakeCatalogue();
+        $this->fakeMosmix();
+
+        app(DwdService::class)->fetchForecast();
+
+        $this->assertNotNull(
+            \Illuminate\Support\Facades\Cache::get(\App\Support\ForecastCacheKeys::forSource('fct_dwd_block.php')),
+            'the page looks here and found nothing'
+        );
+    }
+
     public function test_a_failed_download_returns_nothing_rather_than_throwing(): void
     {
         Http::fake(['opendata.dwd.de/*' => Http::response('gone', 404)]);

--- a/tests/Feature/ForecastResilienceTest.php
+++ b/tests/Feature/ForecastResilienceTest.php
@@ -35,6 +35,21 @@ class ForecastResilienceTest extends TestCase
         Setting::setValue('station.longitude', '13.32', 'float', 'station');
     }
 
+    /** One forecast entry shaped the way the readers expect. */
+    private static function entry(): array
+    {
+        return [
+            'time' => now()->toIso8601String(),
+            'temperature' => 12.0,
+            'symbol' => 'clearsky_day',
+            'wind_speed' => 3.0,
+            'wind_direction' => 180,
+            'precipitation_1h' => 0.0,
+            'humidity' => 60,
+            'cloud_cover' => 10,
+        ];
+    }
+
     private function encryptedRow(string $key, string $rawValue): void
     {
         Setting::create([
@@ -84,12 +99,53 @@ class ForecastResilienceTest extends TestCase
         $this->assertInstanceOf(OpenWeatherMapService::class, ForecastServiceFactory::make());
     }
 
+    /**
+     * The badge read the Yr.no key whatever source was chosen, so every other
+     * source went "Offline" about an hour after being selected.
+     */
+    public function test_the_health_check_follows_the_configured_source(): void
+    {
+        Setting::setValue('forecast.default_source', 'fct_aemet_block.php', 'string', 'forecast');
+        Setting::setValue('aemet.municipio', '28079', 'string', 'aemet');
+
+        $fresh = ['updated_at' => now()->toIso8601String(), 'forecast' => [self::entry()]];
+        \App\Support\CacheFreshness::put('aemet_forecast_28079', $fresh, now()->addHours(2));
+
+        $this->artisan('weather:check-sensor-health')->run();
+
+        $health = Cache::get('data_source_health');
+        $this->assertNotNull($health, 'the health check wrote nothing');
+        $this->assertFalse(
+            $health['forecast']['is_stale'] ?? true,
+            'AEMET data is fresh, so the badge must not say the forecast is stale'
+        );
+    }
+
+    /** A source that cached a well formed but empty payload blocked the fallback. */
+    public function test_an_empty_payload_falls_back_to_the_shared_forecast(): void
+    {
+        Setting::setValue('forecast.default_source', 'fct_wu_block.php', 'string', 'forecast');
+
+        $good = ['updated_at' => now()->toIso8601String(), 'forecast' => [self::entry()]];
+        Cache::put('wunderground_forecast_52.57_13.32', ['updated_at' => now()->toIso8601String(), 'forecast' => []], now()->addHour());
+        Cache::put('forecast_52.57_13.32', $good, now()->addHour());
+
+        $response = $this->withoutMiddleware(\App\Http\Middleware\ApiKeyMiddleware::class)
+            ->getJson('/api/weather/forecast');
+
+        $response->assertOk();
+        $this->assertNotEmpty(
+            $response->json('data.daily') ?: $response->json('data.hourly') ?: [],
+            'the empty payload hid the forecast that was still there'
+        );
+    }
+
     /** The poller cleared the cache first, so a failed fetch lost the last good forecast. */
     public function test_a_failed_poll_keeps_the_forecast_it_already_had(): void
     {
         Setting::setValue('forecast.default_source', 'fct_yrno_block.php', 'string', 'forecast');
 
-        $good = ['updated_at' => now()->toIso8601String(), 'forecast' => [['time' => 'now', 'temperature' => 12]]];
+        $good = ['updated_at' => now()->toIso8601String(), 'forecast' => [self::entry()]];
         Cache::put('forecast_52.57_13.32', $good, now()->addHours(2));
         Cache::put('yrno_forecast_52.57_13.32', $good, now()->addHours(2));
 

--- a/tests/Feature/ForecastResilienceTest.php
+++ b/tests/Feature/ForecastResilienceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Setting;
+use App\Services\Forecast\ForecastServiceFactory;
+use App\Services\Forecast\OpenWeatherMapService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * Issue #99: every forecast source except Yr.no stopped updating.
+ *
+ * An encrypted setting that is empty, or that cannot be decrypted because
+ * APP_KEY changed, reads back as null rather than the default. That null went
+ * into a typed string property and threw a TypeError, which the factory did
+ * not catch because it only catches Exception. The poller clears the cache
+ * before it builds the service, so every run deleted the forecast and then
+ * died before writing anything back.
+ */
+class ForecastResilienceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Setting::setValue('station.latitude', '52.57', 'float', 'station');
+        Setting::setValue('station.longitude', '13.32', 'float', 'station');
+    }
+
+    private function encryptedRow(string $key, string $rawValue): void
+    {
+        Setting::create([
+            'key' => $key,
+            'value' => $rawValue,
+            'type' => 'encrypted',
+            'group' => 'openweathermap',
+        ]);
+    }
+
+    public function test_an_empty_api_key_reads_as_the_default_not_null(): void
+    {
+        $this->encryptedRow('openweathermap.api_key', '');
+
+        $this->assertSame('', Setting::getValue('openweathermap.api_key', ''));
+    }
+
+    /** APP_KEY changed between container restarts, so the stored key is gibberish. */
+    public function test_an_undecryptable_api_key_reads_as_the_default_not_null(): void
+    {
+        $this->encryptedRow('openweathermap.api_key', 'not-actually-encrypted');
+
+        $this->assertSame('', Setting::getValue('openweathermap.api_key', ''));
+    }
+
+    public function test_a_key_that_still_decrypts_is_untouched(): void
+    {
+        $this->encryptedRow('openweathermap.api_key', Crypt::encryptString('real-key'));
+
+        $this->assertSame('real-key', Setting::getValue('openweathermap.api_key', ''));
+    }
+
+    public function test_building_the_service_with_an_unreadable_key_does_not_throw(): void
+    {
+        $this->encryptedRow('openweathermap.api_key', 'not-actually-encrypted');
+
+        $service = new OpenWeatherMapService();
+
+        $this->assertNull($service->fetchForecast(), 'no key means no forecast, not a crash');
+    }
+
+    public function test_the_factory_survives_a_source_it_cannot_build(): void
+    {
+        $this->encryptedRow('openweathermap.api_key', 'not-actually-encrypted');
+        Setting::setValue('forecast.default_source', 'fct_darksky_block.php', 'string', 'forecast');
+
+        $this->assertInstanceOf(OpenWeatherMapService::class, ForecastServiceFactory::make());
+    }
+
+    /** The poller cleared the cache first, so a failed fetch lost the last good forecast. */
+    public function test_a_failed_poll_keeps_the_forecast_it_already_had(): void
+    {
+        Setting::setValue('forecast.default_source', 'fct_yrno_block.php', 'string', 'forecast');
+
+        $good = ['updated_at' => now()->toIso8601String(), 'forecast' => [['time' => 'now', 'temperature' => 12]]];
+        Cache::put('forecast_52.57_13.32', $good, now()->addHours(2));
+        Cache::put('yrno_forecast_52.57_13.32', $good, now()->addHours(2));
+
+        Http::fake(['*' => Http::response('upstream is down', 500)]);
+
+        // A failed poll reports failure, which is right. What matters is what it left behind.
+        $this->artisan('weather:poll-external --source=forecast')->run();
+
+        $this->assertSame($good, Cache::get('forecast_52.57_13.32'), 'the good forecast was destroyed');
+    }
+}


### PR DESCRIPTION
Fixes #99.

The report was about DWD, but the reporter's edit is the important part: OpenWeatherMap and Weather Underground failed the same way with keys that work in other software, and only Yr.no kept running. There are four separate faults here, and they compound.

## 1. An unreadable API key crashed the poller

An encrypted setting that is empty, or that cannot be decrypted because `APP_KEY` changed, reads back as `null` rather than the default the caller asked for. Proven:

```
getValue returns: NULL
constructor THREW: TypeError: Cannot assign null to property ...$apiKey of type string
factory THREW: TypeError (not caught)
```

`ForecastServiceFactory` only catches `Exception`, and a `TypeError` is an `Error`, so it never reached the Yr.no fallback that was supposed to cover this. `Setting::getValue()` now honours the default it was given.

This matters especially in Docker: if `APP_KEY` is not persisted across a container recreate, every encrypted setting silently becomes null, so keys that genuinely work elsewhere stop working here.

## 2. The poller deleted good data before fetching

`pollForecast()` cleared both cache keys, then only wrote back on success, while printing `No forecast data received (keeping existing cache)`. The cache was already gone. One failed fetch emptied the forecast until the next good one.

It now snapshots both keys, restores them when the fetch fails or is rejected, and catches `Throwable` rather than `Exception` around building the service, which is where fault 1 threw.

## 3. DWD could never populate the cache

Mine, from #95. `DwdService` returned `['station' => ..., 'hourly' => ...]`, but the poller and both readers require a top-level `forecast` key, so the payload was discarded on every poll however good it was.

The cache key was wrong too: the reader built it from the configured station while the service wrote under the station it resolved, and resolving one is the default. So the forecast the reporter saw at first was leftover Yr.no data from the shared key, labelled "DWD" by the page.

## 4. The Offline badge always read the Yr.no key

`CheckSensorHealth` hardcoded `yrno_forecast_{lat}_{lon}` whatever source was selected, so any other source showed "Offline" about an hour after being chosen and sent an alert titled "Forecast Data (Yr.no)", regardless of whether its data was fine.

## Why only Yr.no survived all this

It is privileged in four places: only Yr.no refetches on a page request, only Yr.no shaped keys satisfy the five minute self heal, only its Test button warms the key the dashboard reads, and the factory falls back to it.

## Also

The source to cache key map existed in **seven** copies and every one disagreed. It now lives in `app/Support/ForecastCacheKeys.php`. An empty payload counts as a miss, so a source that cached a well formed but empty envelope no longer blocks the shared fallback.

## Tests

Ten new, 501 total. Each fix was reverted to confirm its test fails without it, because a test that passes either way is worse than none.

Agents reproduced Weather Underground end to end by running the real poller against faked HTTP: two 200 responses in, zero forecast entries out, shared key destroyed.

## Not fixed here

**Weather Underground's parser still looks wrong.** It reads `vt1hourlyForecasts`, a v1 envelope the v3 endpoint it calls does not return, and reads `windSpeed` and `iconCode` from the top level of the daily response where v3 nests them under `daypart[0]`. That needs one real captured response to fix properly, and it deserves its own PR with a fixture. After this PR it fails safely instead of destroying the cache.

**OpenWeatherMap has no reproducible parse defect.** If the reporter's key is readable it should work; if it is not, fault 1 covers it.